### PR TITLE
Add resource subscription 

### DIFF
--- a/src/proxyServer.ts
+++ b/src/proxyServer.ts
@@ -9,6 +9,8 @@ import {
   ListToolsRequestSchema,
   LoggingMessageNotificationSchema,
   ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
   ServerCapabilities,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -56,6 +58,16 @@ export const proxyServer = async ({
     server.setRequestHandler(ReadResourceRequestSchema, async (args) => {
       return client.readResource(args.params);
     });
+
+    if (serverCapabilities?.resources.subscribe) {
+      server.setRequestHandler(SubscribeRequestSchema, async (args) => {
+        return client.subscribeResource(args.params);
+      });
+
+      server.setRequestHandler(UnsubscribeRequestSchema, async (args) => {
+        return client.unsubscribeResource(args.params);
+      });
+    }
   }
 
   if (serverCapabilities?.tools) {

--- a/src/simple-stdio-server.ts
+++ b/src/simple-stdio-server.ts
@@ -1,6 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
+  ListResourceTemplatesRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
   SubscribeRequestSchema,
@@ -44,6 +45,18 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   } else {
     throw new Error("Resource not found");
   }
+});
+
+server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+  return {
+    resourceTemplates: [
+      {
+        uriTemplate: `file://{filename}`,
+        name: "Example resource template",
+        description: "Specify the filename to retrieve",
+      },
+    ],
+  };
 });
 
 server.setRequestHandler(SubscribeRequestSchema, async () => {

--- a/src/simple-stdio-server.ts
+++ b/src/simple-stdio-server.ts
@@ -3,6 +3,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
 const server = new Server(
@@ -12,7 +14,7 @@ const server = new Server(
   },
   {
     capabilities: {
-      resources: {},
+      resources: { subscribe: true },
     },
   },
 );
@@ -42,6 +44,14 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   } else {
     throw new Error("Resource not found");
   }
+});
+
+server.setRequestHandler(SubscribeRequestSchema, async () => {
+  return {};
+});
+
+server.setRequestHandler(UnsubscribeRequestSchema, async () => {
+  return {};
 });
 
 const transport = new StdioServerTransport();

--- a/src/startSSEServer.test.ts
+++ b/src/startSSEServer.test.ts
@@ -50,7 +50,7 @@ it("proxies messages between SSE and stdio servers", async () => {
         capabilities: serverCapabilities,
       });
 
-      proxyServer({
+      await proxyServer({
         server: mcpServer,
         client: stdioClient,
         serverCapabilities,
@@ -80,7 +80,8 @@ it("proxies messages between SSE and stdio servers", async () => {
 
   await sseClient.connect(transport);
 
-  expect(await sseClient.listResources()).toEqual({
+  const result = await sseClient.listResources();
+  expect(result).toEqual({
     resources: [
       {
         uri: "file:///example.txt",
@@ -88,6 +89,18 @@ it("proxies messages between SSE and stdio servers", async () => {
       },
     ],
   });
+
+  expect(await sseClient.readResource({uri: (result.resources[0].uri)},{})).toEqual({
+    contents: [
+      {
+        uri: "file:///example.txt",
+        mimeType: "text/plain",
+        text: "This is the content of the example resource.",
+      },
+    ],
+  });
+  expect(await sseClient.subscribeResource({ uri: "xyz" })).toEqual({});
+  expect(await sseClient.unsubscribeResource({ uri: "xyz" })).toEqual({});
 
   expect(onConnect).toHaveBeenCalled();
   expect(onClose).not.toHaveBeenCalled();

--- a/src/startSSEServer.test.ts
+++ b/src/startSSEServer.test.ts
@@ -101,6 +101,16 @@ it("proxies messages between SSE and stdio servers", async () => {
   });
   expect(await sseClient.subscribeResource({ uri: "xyz" })).toEqual({});
   expect(await sseClient.unsubscribeResource({ uri: "xyz" })).toEqual({});
+  expect(await sseClient.listResourceTemplates()).toEqual({
+    resourceTemplates: [
+      {
+        uriTemplate: `file://{filename}`,
+        name: "Example resource template",
+        description: "Specify the filename to retrieve",
+      },
+    ],
+  });
+
 
   expect(onConnect).toHaveBeenCalled();
   expect(onClose).not.toHaveBeenCalled();


### PR DESCRIPTION
See the [Resource updates]https://modelcontextprotocol.io/docs/concepts/resources#resource-updates) section of the protocol for details.

* In proxyServer.ts,
  - import SubscribeRequestSchema and UnsubscribeRequestSchema from sdk.
  - when server capabilities include resource subscriptions
    - add handler for SubscribeRequestSchema which calls client.subscribeResource, passing the request params
    - add handler for UnsubscribeRequestSchema which calls client.unsubscribeResource, passing the request params

* In simple-stdio-server.ts
  - set resources.subscribe to true in server config in server capabilities
  - added SubscribeRequestSchema and UnsubscribeRequestSchema handlers that return an empty object. There are no specified response parameters in the spec.
  - added ListResourceTemplatesRequestSchema request handler that returns an appropriate dummy result. 

* In startSSEServer.test.ts,
  - add await on async call to proxyServer in the createServer function. Ensuring proxyServer method is complete before caller can attempt to use mcpServer.
  - add calls to
    - sseClient.readResource
    - sseClient.subscribeResource
    - sseClient.unsubscribeResource
    - client.listResourceTemplates

* This fixes #3 