### PR TITLE
Add resource update notification handler

### DIFF
--- a/src/proxyServer.ts
+++ b/src/proxyServer.ts
@@ -11,6 +11,7 @@ import {
   ReadResourceRequestSchema,
   SubscribeRequestSchema,
   UnsubscribeRequestSchema,
+  ResourceUpdatedNotificationSchema,
   ServerCapabilities,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -60,6 +61,13 @@ export const proxyServer = async ({
     });
 
     if (serverCapabilities?.resources.subscribe) {
+      server.setNotificationHandler(
+          ResourceUpdatedNotificationSchema,
+          async (args) => {
+            return client.notification(args);
+          },
+      );
+
       server.setRequestHandler(SubscribeRequestSchema, async (args) => {
         return client.subscribeResource(args.params);
       });


### PR DESCRIPTION
Previously I [added support for subscribing to resources](https://github.com/punkpeye/mcp-proxy/pull/4), which works but omitted the handler for subsequent resource update notifications coming from the server.

* In proxyServer.ts
  - if resource subscriptions are supported, add notification handler for ResourceUpdatedNotificationSchema


