### PR TITLE
Feat: introduce startHTTPStreamServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ npm install mcp-proxy
 npx mcp-proxy --port 8080 --endpoint /sse tsx server.js
 ```
 
-This starts an SSE server and `stdio` server (`tsx server.js`). The SSE server listens on port 8080 and endpoint `/sse`, and forwards messages to the `stdio` server.
+This starts a server and `stdio` server (`tsx server.js`). The server listens on port 8080 and endpoint `/sse` by default, and forwards messages to the `stdio` server.
+
+options:
+
+- `--port`: Specify the port to listen on (default: 8080)
+- `--endpoint`: Specify the endpoint to listen on (default: `/sse` for SSE server, `/stream` for stream server)
+- `--server`: Specify the server type to use (default: `sse`)
+- `--debug`: Enable debug logging
 
 ### Node.js SDK
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ const { close } = await startSSEServer({
 close();
 ```
 
+#### `startHTTPStreamServer`
+
+Starts a proxy that listens on a `port` and `endpoint`, and sends messages to the attached server via `StreamableHTTPServerTransport`.
+
+```ts
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { startHTTPStreamServer } from "mcp-proxy";
+
+const { close } = await startHTTPStreamServer({
+  port: 8080,
+  endpoint: "/stream",
+  createServer: async () => {
+    return new Server();
+  },
+  eventStore: new InMemoryEventStore(), // optional you can provide your own event store
+});
+
+close();
+```
+
 #### `tapTransport`
 
 Taps into a transport and logs events.

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -9,7 +9,9 @@ import { setTimeout } from "node:timers";
 import { StdioClientTransport } from "../StdioClientTransport.js";
 import util from "node:util";
 import { startSSEServer } from "../startSSEServer.js";
+import { startHTTPStreamServer } from "../startHTTPStreamServer.js";
 import { proxyServer } from "../proxyServer.js";
+import { InMemoryEventStore } from "../inMemoryEventStore.js";
 
 util.inspect.defaultOptions.depth = 8;
 
@@ -40,13 +42,18 @@ const argv = await yargs(hideBin(process.argv))
     },
     endpoint: {
       type: "string",
-      describe: "The endpoint to listen on for SSE",
-      default: "/sse",
+      describe: "The endpoint to listen on",
     },
     port: {
       type: "number",
-      describe: "The port to listen on for SSE",
+      describe: "The port to listen on",
       default: 8080,
+    },
+    server: {
+      type: "string",
+      describe: "The server type to use (sse or stream)",
+      choices: ["sse", "stream"],
+      default: "sse",
     },
   })
   .help()
@@ -76,7 +83,7 @@ const proxy = async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   await connect(client);
@@ -88,25 +95,36 @@ const proxy = async () => {
 
   const serverCapabilities = client.getServerCapabilities() as {};
 
-  console.info("starting the SSE server on port %d", argv.port);
+  console.info("starting the %s server on port %d", argv.server, argv.port);
 
-  await startSSEServer({
-    createServer: async () => {
-      const server = new Server(serverVersion, {
-        capabilities: serverCapabilities,
-      });
+  const createServer = async () => {
+    const server = new Server(serverVersion, {
+      capabilities: serverCapabilities,
+    });
 
-      proxyServer({
-        server,
-        client,
-        serverCapabilities,
-      });
+    proxyServer({
+      server,
+      client,
+      serverCapabilities,
+    });
 
-      return server;
-    },
-    port: argv.port,
-    endpoint: argv.endpoint as `/${string}`,
-  });
+    return server;
+  };
+
+  if (argv.server === "sse") {
+    await startSSEServer({
+      createServer,
+      port: argv.port,
+      endpoint: argv.endpoint || ("/sse" as `/${string}`),
+    });
+  } else {
+    await startHTTPStreamServer({
+      createServer,
+      port: argv.port,
+      endpoint: argv.endpoint || ("/stream" as `/${string}`),
+      eventStore: new InMemoryEventStore(),
+    });
+  }
 };
 
 const main = async () => {

--- a/src/inMemoryEventStore.ts
+++ b/src/inMemoryEventStore.ts
@@ -1,0 +1,88 @@
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import type { EventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+// copied from https://github.com/modelcontextprotocol/typescript-sdk
+
+/**
+ * Simple in-memory implementation of the EventStore interface for resumability
+ * This is primarily intended for examples and testing, not for production use
+ * where a persistent storage solution would be more appropriate.
+ */
+export class InMemoryEventStore implements EventStore {
+  private events: Map<string, { streamId: string; message: JSONRPCMessage }> =
+    new Map();
+
+  /**
+   * Generates a unique event ID for a given stream ID
+   */
+  private generateEventId(streamId: string): string {
+    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
+  }
+
+  /**
+   * Extracts the stream ID from an event ID
+   */
+  private getStreamIdFromEventId(eventId: string): string {
+    const parts = eventId.split("_");
+    return parts.length > 0 ? parts[0] : "";
+  }
+
+  /**
+   * Stores an event with a generated event ID
+   * Implements EventStore.storeEvent
+   */
+  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
+    const eventId = this.generateEventId(streamId);
+    this.events.set(eventId, { streamId, message });
+    return eventId;
+  }
+
+  /**
+   * Replays events that occurred after a specific event ID
+   * Implements EventStore.replayEventsAfter
+   */
+  async replayEventsAfter(
+    lastEventId: string,
+    {
+      send,
+    }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
+  ): Promise<string> {
+    if (!lastEventId || !this.events.has(lastEventId)) {
+      return "";
+    }
+
+    // Extract the stream ID from the event ID
+    const streamId = this.getStreamIdFromEventId(lastEventId);
+    if (!streamId) {
+      return "";
+    }
+
+    let foundLastEvent = false;
+
+    // Sort events by eventId for chronological ordering
+    const sortedEvents = [...this.events.entries()].sort((a, b) =>
+      a[0].localeCompare(b[0])
+    );
+
+    for (const [
+      eventId,
+      { streamId: eventStreamId, message },
+    ] of sortedEvents) {
+      // Only include events from the same stream
+      if (eventStreamId !== streamId) {
+        continue;
+      }
+
+      // Start sending events after we find the lastEventId
+      if (eventId === lastEventId) {
+        foundLastEvent = true;
+        continue;
+      }
+
+      if (foundLastEvent) {
+        await send(eventId, message);
+      }
+    }
+    return streamId;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { tapTransport } from "./tapTransport.js";
 export { proxyServer } from "./proxyServer.js";
 export { startSSEServer } from "./startSSEServer.js";
+export { startHTTPStreamServer } from "./startHTTPStreamServer.js";

--- a/src/startHTTPStreamServer.test.ts
+++ b/src/startHTTPStreamServer.test.ts
@@ -1,0 +1,127 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { it, expect, vi } from "vitest";
+import { startHTTPStreamServer } from "./startHTTPStreamServer.js";
+import { getRandomPort } from "get-port-please";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { EventSource } from "eventsource";
+import { setTimeout as delay } from "node:timers/promises";
+import { proxyServer } from "./proxyServer.js";
+
+if (!("EventSource" in global)) {
+  // @ts-expect-error - figure out how to use --experimental-eventsource with vitest
+  global.EventSource = EventSource;
+}
+
+it("proxies messages between HTTP stream and stdio servers", async () => {
+  const stdioTransport = new StdioClientTransport({
+    command: "tsx",
+    args: ["src/simple-stdio-server.ts"],
+  });
+
+  const stdioClient = new Client(
+    {
+      name: "mcp-proxy",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {},
+    }
+  );
+
+  await stdioClient.connect(stdioTransport);
+
+  const serverVersion = stdioClient.getServerVersion() as {
+    name: string;
+    version: string;
+  };
+
+  const serverCapabilities = stdioClient.getServerCapabilities() as {};
+
+  const port = await getRandomPort();
+
+  const onConnect = vi.fn();
+  const onClose = vi.fn();
+
+  await startHTTPStreamServer({
+    createServer: async () => {
+      const mcpServer = new Server(serverVersion, {
+        capabilities: serverCapabilities,
+      });
+
+      await proxyServer({
+        server: mcpServer,
+        client: stdioClient,
+        serverCapabilities,
+      });
+
+      return mcpServer;
+    },
+    port,
+    endpoint: "/stream",
+    onConnect,
+    onClose,
+  });
+
+  const streamClient = new Client(
+    {
+      name: "stream-client",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {},
+    }
+  );
+
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://localhost:${port}/stream`)
+  );
+
+  await streamClient.connect(transport);
+
+  const result = await streamClient.listResources();
+  expect(result).toEqual({
+    resources: [
+      {
+        uri: "file:///example.txt",
+        name: "Example Resource",
+      },
+    ],
+  });
+
+  expect(
+    await streamClient.readResource({ uri: result.resources[0].uri }, {})
+  ).toEqual({
+    contents: [
+      {
+        uri: "file:///example.txt",
+        mimeType: "text/plain",
+        text: "This is the content of the example resource.",
+      },
+    ],
+  });
+  expect(await streamClient.subscribeResource({ uri: "xyz" })).toEqual({});
+  expect(await streamClient.unsubscribeResource({ uri: "xyz" })).toEqual({});
+  expect(await streamClient.listResourceTemplates()).toEqual({
+    resourceTemplates: [
+      {
+        uriTemplate: `file://{filename}`,
+        name: "Example resource template",
+        description: "Specify the filename to retrieve",
+      },
+    ],
+  });
+
+  expect(onConnect).toHaveBeenCalled();
+  expect(onClose).not.toHaveBeenCalled();
+
+  // the transport no requires the function terminateSession to be called but the client does not implement it
+  // so we need to call it manually
+  await transport.terminateSession();
+  await streamClient.close();
+
+  await delay(1000);
+
+  expect(onClose).toHaveBeenCalled();
+});

--- a/src/startHTTPStreamServer.ts
+++ b/src/startHTTPStreamServer.ts
@@ -1,0 +1,280 @@
+import {
+  EventStore,
+  StreamableHTTPServerTransport,
+} from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { randomUUID } from "node:crypto";
+import http from "http";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { InMemoryEventStore } from "./inMemoryEventStore.js";
+
+export type SSEServer = {
+  close: () => Promise<void>;
+};
+
+type ServerLike = {
+  connect: Server["connect"];
+  close: Server["close"];
+};
+
+export const startHTTPStreamServer = async <T extends ServerLike>({
+  port,
+  createServer,
+  endpoint,
+  eventStore,
+  onConnect,
+  onClose,
+  onUnhandledRequest,
+}: {
+  port: number;
+  endpoint: string;
+  createServer: (request: http.IncomingMessage) => Promise<T>;
+  eventStore?: EventStore;
+  onConnect?: (server: T) => void;
+  onClose?: (server: T) => void;
+  onUnhandledRequest?: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ) => Promise<void>;
+}): Promise<SSEServer> => {
+  const activeTransports: Record<
+    string,
+    {
+      transport: StreamableHTTPServerTransport;
+      server: T;
+    }
+  > = {};
+
+  /**
+   * @author https://dev.classmethod.jp/articles/mcp-sse/
+   */
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.headers.origin) {
+      try {
+        const origin = new URL(req.headers.origin);
+
+        res.setHeader("Access-Control-Allow-Origin", origin.origin);
+        res.setHeader("Access-Control-Allow-Credentials", "true");
+        res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+        res.setHeader("Access-Control-Allow-Headers", "*");
+      } catch (error) {
+        console.error("Error parsing origin:", error);
+      }
+    }
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.method === "GET" && req.url === `/ping`) {
+      res.writeHead(200).end("pong");
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      new URL(req.url!, "http://localhost").pathname === endpoint
+    ) {
+      try {
+        const sessionId = Array.isArray(req.headers["mcp-session-id"])
+          ? req.headers["mcp-session-id"][0]
+          : req.headers["mcp-session-id"];
+        let transport: StreamableHTTPServerTransport;
+        let server: T;
+
+        const body = await getBody(req);
+
+        if (sessionId && activeTransports[sessionId]) {
+          transport = activeTransports[sessionId].transport;
+          server = activeTransports[sessionId].server;
+        } else if (!sessionId && isInitializeRequest(body)) {
+          // Create a new transport for the session
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            eventStore: eventStore || new InMemoryEventStore(),
+            onsessioninitialized: (_sessionId) => {
+              // add only when the id Sesison id is generated
+              activeTransports[_sessionId] = {
+                transport,
+                server,
+              };
+            },
+          });
+
+          // Handle the server close event
+          transport.onclose = async () => {
+            const sid = transport.sessionId;
+            if (sid && activeTransports[sid]) {
+              onClose?.(server);
+              try {
+                await server.close();
+              } catch (error) {
+                console.error("Error closing server:", error);
+              }
+              delete activeTransports[sid];
+            }
+          };
+
+          // Create the server
+          try {
+            server = await createServer(req);
+          } catch (error) {
+            if (error instanceof Response) {
+              res.writeHead(error.status).end(error.statusText);
+              return;
+            }
+            res.writeHead(500).end("Error creating server");
+            return;
+          }
+
+          server.connect(transport);
+          onConnect?.(server);
+
+          await transport.handleRequest(req, res, body);
+          return;
+        } else {
+          // Error if the server is not created but the request is not an initialize request
+          res.setHeader("Content-Type", "application/json");
+          res.writeHead(400).end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message: "Bad Request: No valid session ID provided",
+              },
+              id: null,
+            })
+          );
+
+          return;
+        }
+
+        // Handle ther request if the server is already created
+        await transport.handleRequest(req, res, body);
+      } catch (error) {
+        console.error("Error handling request:", error);
+        res.setHeader("Content-Type", "application/json");
+        res.writeHead(500).end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32603, message: "Internal Server Error" },
+            id: null,
+          })
+        );
+      }
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      new URL(req.url!, "http://localhost").pathname === endpoint
+    ) {
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      const activeTransport:
+        | {
+            transport: StreamableHTTPServerTransport;
+            server: T;
+          }
+        | undefined = sessionId ? activeTransports[sessionId] : undefined;
+
+      if (!sessionId) {
+        res.writeHead(400).end("No sessionId");
+        return;
+      }
+
+      if (!activeTransport) {
+        res.writeHead(400).end("No active transport");
+        return;
+      }
+
+      const lastEventId = req.headers["last-event-id"] as string | undefined;
+      if (lastEventId) {
+        console.log(`Client reconnecting with Last-Event-ID: ${lastEventId}`);
+      } else {
+        console.log(`Establishing new SSE stream for session ${sessionId}`);
+      }
+
+      await activeTransport.transport.handleRequest(req, res);
+      return;
+    }
+
+    if (
+      req.method === "DELETE" &&
+      new URL(req.url!, "http://localhost").pathname === endpoint
+    ) {
+      console.log("received delete request");
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      if (!sessionId) {
+        res.writeHead(400).end("Invalid or missing sessionId");
+        return;
+      }
+
+      console.log("received delete request for session", sessionId);
+
+      const { transport, server } = activeTransports[sessionId];
+      if (!transport) {
+        res.writeHead(400).end("No active transport");
+        return;
+      }
+
+      try {
+        await transport.handleRequest(req, res);
+        onClose?.(server);
+      } catch (error) {
+        console.error("Error handling delete request:", error);
+        res.writeHead(500).end("Error handling delete request");
+      }
+
+      return;
+    }
+
+    if (onUnhandledRequest) {
+      await onUnhandledRequest(req, res);
+    } else {
+      res.writeHead(404).end();
+    }
+  });
+
+  await new Promise((resolve) => {
+    httpServer.listen(port, "::", () => {
+      resolve(undefined);
+    });
+  });
+
+  return {
+    close: async () => {
+      for (const transport of Object.values(activeTransports)) {
+        await transport.transport.close();
+      }
+
+      return new Promise((resolve, reject) => {
+        httpServer.close((error) => {
+          if (error) {
+            reject(error);
+
+            return;
+          }
+
+          resolve();
+        });
+      });
+    },
+  };
+};
+
+function getBody(request: http.IncomingMessage) {
+  return new Promise((resolve) => {
+    const bodyParts: Buffer[] = [];
+    let body: string;
+    request
+      .on("data", (chunk) => {
+        bodyParts.push(chunk);
+      })
+      .on("end", () => {
+        body = Buffer.concat(bodyParts).toString();
+        resolve(JSON.parse(body));
+      });
+  });
+}


### PR DESCRIPTION
- Added `startHTTPStreamServer` function to create a proxy server for HTTP streaming.
- Implemented `InMemoryEventStore` for event storage, primarily for testing and examples.
- Updated README with usage instructions for the new server.
- Added tests for the HTTP stream server functionality.
- Added option to choose server type in `mcp-proxy`