### PR TITLE
handle body is not a json

### DIFF
--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -29,7 +29,12 @@ const getBody = (request: http.IncomingMessage) => {
       })
       .on("end", () => {
         body = Buffer.concat(bodyParts).toString();
-        resolve(JSON.parse(body));
+        try {
+          resolve(JSON.parse(body));
+        } catch(error) {
+          console.error("Error parsing body:", error);
+          resolve(null);
+        }
       });
   });
 };


### PR DESCRIPTION
When the server starts with a basic httpStream configuration, the following request:

`curl -X POST -H "Content-Type: application/json" http://localhost:8080/stream`

causes the server to crash, because the body is empty.