### PR TITLE
feat: add options for custom SSE and stream endpoint paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This starts a server and `stdio` server (`tsx server.js`). The server listens on
 
 options:
 
+- `--server`: Set to `sse` or `stream` to only enable the respective transport (default: both)
+- `--endpoint`: If `server` is set to `sse` or `stream`, this option sets the endpoint path (default: `/sse` or `/stream`)
+- `--sseEndpoint`: Set the SSE endpoint path (default: `/sse`). Overrides `--endpoint` if `server` is set to `sse`.
+- `--streamEndpoint`: Set the streamable HTTP endpoint path (default: `/stream`). Overrides `--endpoint` if `server` is set to `stream`.
 - `--port`: Specify the port to listen on (default: 8080)
 - `--debug`: Enable debug logging
 - `--shell`: Spawn the server via the user's shell

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -44,6 +44,16 @@ const argv = await yargs(hideBin(process.argv))
       describe: "The endpoint to listen on",
       type: "string",
     },
+    sseEndpoint: {
+      default: "/sse",
+      describe: "The SSE endpoint to listen on",
+      type: "string",
+    },
+    streamEndpoint: {
+      default: "/stream",
+      describe: "The stream endpoint to listen on",
+      type: "string",
+    },
     port: {
       default: 8080,
       describe: "The port to listen on",
@@ -51,8 +61,7 @@ const argv = await yargs(hideBin(process.argv))
     },
     server: {
       choices: ["sse", "stream"],
-      default: "sse",
-      describe: "The server type to use (sse or stream)",
+      describe: "The server type to use (sse or stream). By default, both are enabled",
       type: "string",
     },
     shell: {
@@ -123,6 +132,8 @@ const proxy = async () => {
     createServer,
     eventStore: new InMemoryEventStore(),
     port: argv.port,
+    sseEndpoint: argv.server && argv.server !== "sse" ? null : (argv.sseEndpoint ?? argv.endpoint),
+    streamEndpoint: argv.server && argv.server !== "stream" ? null : (argv.streamEndpoint ?? argv.endpoint),
   });
 };
 

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -44,16 +44,6 @@ const argv = await yargs(hideBin(process.argv))
       describe: "The endpoint to listen on",
       type: "string",
     },
-    sseEndpoint: {
-      default: "/sse",
-      describe: "The SSE endpoint to listen on",
-      type: "string",
-    },
-    streamEndpoint: {
-      default: "/stream",
-      describe: "The stream endpoint to listen on",
-      type: "string",
-    },
     port: {
       default: 8080,
       describe: "The port to listen on",
@@ -68,6 +58,16 @@ const argv = await yargs(hideBin(process.argv))
       default: false,
       describe: "Spawn the server via the user's shell",
       type: "boolean",
+    },
+    sseEndpoint: {
+      default: "/sse",
+      describe: "The SSE endpoint to listen on",
+      type: "string",
+    },
+    streamEndpoint: {
+      default: "/stream",
+      describe: "The stream endpoint to listen on",
+      type: "string",
     },
   })
   .help()

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -357,6 +357,8 @@ export const startHTTPServer = async <T extends ServerLike>({
   onConnect,
   onUnhandledRequest,
   port,
+  sseEndpoint,
+  streamEndpoint,
 }: {
   createServer: (request: http.IncomingMessage) => Promise<T>;
   eventStore?: EventStore;
@@ -367,6 +369,8 @@ export const startHTTPServer = async <T extends ServerLike>({
     res: http.ServerResponse,
   ) => Promise<void>;
   port: number;
+  sseEndpoint?: string | null;
+  streamEndpoint?: string | null;
 }): Promise<SSEServer> => {
   const activeSSETransports: Record<string, SSEServerTransport> = {};
 
@@ -408,10 +412,11 @@ export const startHTTPServer = async <T extends ServerLike>({
     }
 
     if (
+      sseEndpoint !== null &&
       await handleSSERequest({
         activeTransports: activeSSETransports,
         createServer,
-        endpoint: "/sse",
+        endpoint: sseEndpoint ?? "/sse",
         onClose,
         onConnect,
         req,
@@ -422,10 +427,11 @@ export const startHTTPServer = async <T extends ServerLike>({
     }
 
     if (
+      streamEndpoint !== null &&
       await handleStreamRequest({
         activeTransports: activeStreamTransports,
         createServer,
-        endpoint: "/stream",
+        endpoint: streamEndpoint ?? "/stream",
         eventStore,
         onClose,
         onConnect,

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -369,8 +369,8 @@ export const startHTTPServer = async <T extends ServerLike>({
     res: http.ServerResponse,
   ) => Promise<void>;
   port: number;
-  sseEndpoint?: string | null;
-  streamEndpoint?: string | null;
+  sseEndpoint?: null | string;
+  streamEndpoint?: null | string;
 }): Promise<SSEServer> => {
   const activeSSETransports: Record<string, SSEServerTransport> = {};
 


### PR DESCRIPTION
* add new optional parameters `sseEndpoint` and `streamEndpoint` to `startHTTPServer` to allow passing custom endpoints to listen on.
  * The default value `undefined` ensures backwards compatibility with `/sse` and `/stream` values.
  * If the endpoint is set to `null`, the respective transport (sse or stream) is disabled.
* readd support for `--server` and `--endpoint` CLI args. If `--server` is set to either `sse` or `stream`, only this transport is enabled and the optional `--endpoint` value is used, falling back to the default respective `/sse` or `/stream` values.
* add support for `--sseEndpoint` and `--streamEndpoint` CLI args. If `--server` is not set, the server listens on both the SSE and HTTP stream endpoints. If this is the case, these two args allow the customization of the respective endpoints.

This solves #17 and readds backwards compatibility to the `--endpoint` CLI argument, which existed in version 2 and was still in the code.

Additional thoughts about CLI usage: I'm not sure if the `--server` and `--endpoint` args are still necessary. As they were still in the code's `yargs` option configuration, I decided to make use of them. It allows users to e.g. disable the SSE transport. However, `--endpoint` is kind of obsolete since we have two new endpoint args anyway. This may confuse users.

Please let me know what you think and how the solution could be refined in terms of CLI arguments and their user experience.