### PR TITLE
Fix: Handle session id not found when restart server

### DIFF
--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -76,9 +76,26 @@ const handleStreamRequest = async <T extends ServerLike>({
 
       const body = await getBody(req);
 
-      if (sessionId && activeTransports[sessionId]) {
-        transport = activeTransports[sessionId].transport;
-        server = activeTransports[sessionId].server;
+      if (sessionId) {
+        const activeTransport = activeTransports[sessionId];
+        if (!activeTransport) {
+          res.setHeader('Content-Type', 'application/json');
+          res.writeHead(404).end(
+            JSON.stringify({
+              error: {
+                code: -32001,
+                message: 'Session not found',
+              },
+              id: null,
+              jsonrpc: '2.0',
+            })
+          );
+
+          return true;
+        }
+
+        transport = activeTransport.transport;
+        server = activeTransport.server;
       } else if (!sessionId && isInitializeRequest(body)) {
         // Create a new transport for the session
         transport = new StreamableHTTPServerTransport({
@@ -104,7 +121,7 @@ const handleStreamRequest = async <T extends ServerLike>({
             try {
               await server.close();
             } catch (error) {
-              console.error("[mcp-proxy] error closing server", error);
+              console.error('[mcp-proxy] error closing server', error);
             }
 
             delete activeTransports[sid];
@@ -120,7 +137,7 @@ const handleStreamRequest = async <T extends ServerLike>({
             return true;
           }
 
-          res.writeHead(500).end("Error creating server");
+          res.writeHead(500).end('Error creating server');
 
           return true;
         }
@@ -136,17 +153,17 @@ const handleStreamRequest = async <T extends ServerLike>({
         return true;
       } else {
         // Error if the server is not created but the request is not an initialize request
-        res.setHeader("Content-Type", "application/json");
+        res.setHeader('Content-Type', 'application/json');
 
         res.writeHead(400).end(
           JSON.stringify({
             error: {
               code: -32000,
-              message: "Bad Request: No valid session ID provided",
+              message: 'Bad Request: No valid session ID provided',
             },
             id: null,
-            jsonrpc: "2.0",
-          }),
+            jsonrpc: '2.0',
+          })
         );
 
         return true;

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -79,15 +79,15 @@ const handleStreamRequest = async <T extends ServerLike>({
       if (sessionId) {
         const activeTransport = activeTransports[sessionId];
         if (!activeTransport) {
-          res.setHeader('Content-Type', 'application/json');
+          res.setHeader("Content-Type", "application/json");
           res.writeHead(404).end(
             JSON.stringify({
               error: {
                 code: -32001,
-                message: 'Session not found',
+                message: "Session not found",
               },
               id: null,
-              jsonrpc: '2.0',
+              jsonrpc: "2.0",
             })
           );
 
@@ -121,7 +121,7 @@ const handleStreamRequest = async <T extends ServerLike>({
             try {
               await server.close();
             } catch (error) {
-              console.error('[mcp-proxy] error closing server', error);
+              console.error("[mcp-proxy] error closing server", error);
             }
 
             delete activeTransports[sid];
@@ -137,7 +137,7 @@ const handleStreamRequest = async <T extends ServerLike>({
             return true;
           }
 
-          res.writeHead(500).end('Error creating server');
+          res.writeHead(500).end("Error creating server");
 
           return true;
         }
@@ -153,16 +153,16 @@ const handleStreamRequest = async <T extends ServerLike>({
         return true;
       } else {
         // Error if the server is not created but the request is not an initialize request
-        res.setHeader('Content-Type', 'application/json');
+        res.setHeader("Content-Type", "application/json");
 
         res.writeHead(400).end(
           JSON.stringify({
             error: {
               code: -32000,
-              message: 'Bad Request: No valid session ID provided',
+              message: "Bad Request: No valid session ID provided",
             },
             id: null,
-            jsonrpc: '2.0',
+            jsonrpc: "2.0",
           })
         );
 


### PR DESCRIPTION
in mcp specification it should return status 404 if session id provided is invalid

https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#session-management

> 4.When a client receives HTTP 404 in response to a request containing an Mcp-Session-Id, it MUST start a new session by sending a new InitializeRequest without a session ID attached.

related issue

punkpeye/fastmcp#121

