### PR TITLE
Add stateless support per MCP core documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 package-lock.json
+.DS_Store

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -78,6 +78,11 @@ const argv = await yargs(hideBin(process.argv))
       describe: "The SSE endpoint to listen on",
       type: "string",
     },
+    stateless: {
+      default: false,
+      describe: "Enable stateless mode for HTTP streamable transport (no session management)",
+      type: "boolean",
+    },
     streamEndpoint: {
       default: "/mcp",
       describe: "The stream endpoint to listen on",
@@ -160,6 +165,7 @@ const proxy = async () => {
       argv.server && argv.server !== "sse"
         ? null
         : (argv.sseEndpoint ?? argv.endpoint),
+    stateless: argv.stateless,
     streamEndpoint:
       argv.server && argv.server !== "stream"
         ? null


### PR DESCRIPTION
Feature Support: [Stateless Session](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#without-session-management-stateless)

1. Added new options for `stateless` feature. This will now set `sessionIdGenerator=undefined` per MCP documentation listed above.
2. Created helper functions to reduce code duplication
3. Updated Unit Tests
4. Ran Lint
5. The fork of this change and the change of the fastmcp package have been deployed to our orgs k8s clusters and confirmed resolved the 404 session not found errors for the load balancing to (n) pods.
6. Created issue [#31](https://github.com/punkpeye/mcp-proxy/issues/31) clone from FastMcp

This PR aims to fix [FastMcp Stateless Support](https://github.com/punkpeye/fastmcp/issues/99) issue / question that was created. Will have a follow-up PR for this [FastMCP](https://github.com/punkpeye/fastmcp) issue. 

Feel free to request any desired changes since I made some assumptions / decisions.