### PR TITLE
fix: move onUnhandledRequest before auth middleware

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -692,6 +692,60 @@ it("does not require auth for OPTIONS requests", async () => {
   await httpServer.close();
 });
 
+it("allows onUnhandledRequest to serve routes without auth", async () => {
+  const port = await getRandomPort();
+  const apiKey = "test-api-key-unhandled";
+
+  const httpServer = await startHTTPServer({
+    apiKey,
+    createServer: async () => {
+      const mcpServer = new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+      return mcpServer;
+    },
+    onUnhandledRequest: async (req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(200).end("ok");
+      } else if (req.url === "/ready") {
+        res.writeHead(200).end("ready");
+      }
+      // Don't write response for unknown paths — fall through to MCP handlers
+    },
+    port,
+  });
+
+  // /health works without auth
+  const healthResponse = await fetch(`http://localhost:${port}/health`);
+  expect(healthResponse.status).toBe(200);
+  expect(await healthResponse.text()).toBe("ok");
+
+  // /ready works without auth
+  const readyResponse = await fetch(`http://localhost:${port}/ready`);
+  expect(readyResponse.status).toBe(200);
+  expect(await readyResponse.text()).toBe("ready");
+
+  // POST /mcp without auth still returns 401
+  const mcpResponse = await fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0.0" },
+        protocolVersion: "2025-03-26",
+      },
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+  expect(mcpResponse.status).toBe(401);
+
+  await httpServer.close();
+});
+
 // Stateless OAuth 2.0 JWT Bearer Token Authentication Tests (PR #37)
 
 it("accepts requests with valid Bearer token in stateless mode", async () => {

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -938,7 +938,16 @@ export const startHTTPServer = async <T extends ServerLike>({
       return;
     }
 
-    // Check authentication for all other endpoints
+    // Let non-MCP routes (e.g. /health, /ready, OAuth metadata) be handled
+    // before auth — API key auth protects MCP protocol endpoints, not custom routes.
+    if (onUnhandledRequest) {
+      await onUnhandledRequest(req, res);
+      if (res.writableEnded) {
+        return;
+      }
+    }
+
+    // Check authentication for MCP protocol endpoints
     if (!authMiddleware.validateRequest(req)) {
       const authResponse = authMiddleware.getUnauthorizedResponse();
       res.writeHead(401, authResponse.headers);
@@ -982,11 +991,7 @@ export const startHTTPServer = async <T extends ServerLike>({
       return;
     }
 
-    if (onUnhandledRequest) {
-      await onUnhandledRequest(req, res);
-    } else {
-      res.writeHead(404).end();
-    }
+    res.writeHead(404).end();
   };
 
   let httpServer;


### PR DESCRIPTION
API key auth protects MCP protocol endpoints (SSE, Stream), not custom routes served via onUnhandledRequest. Moving it before auth allows health checks, readiness probes, and other non-MCP routes to be served without requiring API key credentials.

Checks res.writableEnded after onUnhandledRequest — if the handler wrote a response, stop; otherwise continue to auth and MCP handlers.

Fixes #58