### PR TITLE
fix: skip onUnhandledRequest for MCP protocol endpoints

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -746,6 +746,61 @@ it("allows onUnhandledRequest to serve routes without auth", async () => {
   await httpServer.close();
 });
 
+it("routes MCP stream endpoint to handleStreamRequest even when onUnhandledRequest closes response for unknown paths", async () => {
+  // Regression test for the interaction between PR #59 and consumers
+  // (e.g. fastmcp) whose onUnhandledRequest handler writes 404 for any path
+  // it doesn't recognise. Before the fix, the POST /mcp request was served
+  // by onUnhandledRequest (→ 404) and never reached handleStreamRequest.
+  const port = await getRandomPort();
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    // Simulates fastmcp's handleUnhandledRequest: consumes unknown paths
+    // with a 404 because it assumes it runs *after* the MCP protocol handlers.
+    onUnhandledRequest: async (req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(200).end("ok");
+        return;
+      }
+      res.writeHead(404).end();
+    },
+    port,
+  });
+
+  // Sanity: custom route still works (preserves PR #59 behaviour).
+  const healthResponse = await fetch(`http://localhost:${port}/health`);
+  expect(healthResponse.status).toBe(200);
+
+  // The MCP initialize call must reach handleStreamRequest, NOT the 404
+  // fallback inside onUnhandledRequest.
+  const mcpResponse = await fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0.0" },
+        protocolVersion: "2025-03-26",
+      },
+    }),
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+  expect(mcpResponse.status).toBe(200);
+  expect(mcpResponse.headers.get("mcp-session-id")).toBeTruthy();
+
+  await httpServer.close();
+});
+
 // Stateless OAuth 2.0 JWT Bearer Token Authentication Tests (PR #37)
 
 it("accepts requests with valid Bearer token in stateless mode", async () => {

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -938,9 +938,20 @@ export const startHTTPServer = async <T extends ServerLike>({
       return;
     }
 
+    // Determine whether the request targets an MCP protocol endpoint (SSE
+    // or HTTP Stream). For those endpoints, onUnhandledRequest MUST NOT run
+    // first — some consumers (e.g. fastmcp) use it as a catch-all 404 handler
+    // and would otherwise short-circuit the MCP protocol handlers.
+    // Use a fixed base because `host` may be "::" (IPv6 any), which is not a
+    // valid URL authority. We only need pathname here.
+    const requestUrl = new URL(req.url || "", "http://localhost");
+    const isMcpEndpoint =
+      (sseEndpoint && requestUrl.pathname === sseEndpoint) ||
+      (streamEndpoint && requestUrl.pathname === streamEndpoint);
+
     // Let non-MCP routes (e.g. /health, /ready, OAuth metadata) be handled
     // before auth — API key auth protects MCP protocol endpoints, not custom routes.
-    if (onUnhandledRequest) {
+    if (onUnhandledRequest && !isMcpEndpoint) {
       await onUnhandledRequest(req, res);
       if (res.writableEnded) {
         return;


### PR DESCRIPTION
## Problem

Since #59, POST requests to the MCP stream endpoint return `404` when the consumer passes an `onUnhandledRequest` callback that writes a response for unknown paths. This is a silent regression for [fastmcp](https://github.com/punkpeye/fastmcp), which ships a `handleUnhandledRequest` that ends with `res.writeHead(404).end()` as its final fallback — the handler assumes it runs **after** the MCP protocol handlers, which was the pre-#59 contract.

### Minimal reproduction

```ts
const httpServer = await startHTTPServer({
  createServer: async () => new Server({ name: "t", version: "1.0.0" }, { capabilities: {} }),
  onUnhandledRequest: async (_req, res) => { res.writeHead(404).end(); },
  port,
  streamEndpoint: "/mcp",
});

const res = await fetch(`http://localhost:${port}/mcp`, {
  method: "POST",
  headers: {
    "Content-Type": "application/json",
    "Accept": "application/json, text/event-stream",
  },
  body: JSON.stringify({
    jsonrpc: "2.0",
    id: 1,
    method: "initialize",
    params: {
      capabilities: {},
      clientInfo: { name: "t", version: "1.0.0" },
      protocolVersion: "2025-03-26",
    },
  }),
});
// res.status === 404 (expected 200 with mcp-session-id)
```

Before 4c532c3 the flow was `handleStreamRequest` → `onUnhandledRequest`, so the catch-all 404 ran last and never interfered. After 4c532c3 it runs first, so any request that isn't explicitly handled by the user's callback gets turned into a 404 before the MCP handlers ever see it.

## Fix

Detect whether the incoming request targets \`sseEndpoint\` or \`streamEndpoint\`, and if so skip the \`onUnhandledRequest\` hook. Custom routes (everything that isn't an MCP protocol endpoint) still bypass auth exactly like #58/#59 intended.

\`\`\`ts
const requestUrl = new URL(req.url || "", "http://localhost");
const isMcpEndpoint =
  (sseEndpoint && requestUrl.pathname === sseEndpoint) ||
  (streamEndpoint && requestUrl.pathname === streamEndpoint);

if (onUnhandledRequest && !isMcpEndpoint) {
  await onUnhandledRequest(req, res);
  if (res.writableEnded) return;
}
\`\`\`

A fixed base URL is used because \`host\` may be \`"::"\` (IPv6 any), which is not a valid URL authority — we only need the pathname.

## Tests

Adds a regression test that simulates fastmcp's handler (200 for \`/health\`, 404 for everything else) and asserts:

- \`GET /health\` → 200 (preserves #59 behaviour)
- \`POST /mcp\` with a valid \`initialize\` payload → 200 with an \`mcp-session-id\` header

All existing \`startHTTPServer\` tests still pass.

## Related

- Regression introduced in #59 (4c532c3), which addressed #58.
- Affects any fastmcp-based server using the HTTP Stream transport.