### PR TITLE
fix(streamable-http): return 405 (not 400) on GET in stateless mode

### DIFF
--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -688,7 +688,14 @@ const handleStreamRequest = async <T extends ServerLike>({
         }
       | undefined = sessionId ? activeTransports[sessionId] : undefined;
 
-    if (!sessionId) {
+    if (!sessionId) {  
+      // Return METHOD_NOT_ALLOWED so stateless clients' transport stops reconnecting
+      if (stateless) {
+        res.writeHead(405, { Allow: "POST" }).end("Method Not Allowed");
+
+        return true;
+      }
+
       res.writeHead(400).end("No sessionId");
 
       return true;


### PR DESCRIPTION
In stateless mode the server doesn't track sessions, so a long-lived GET SSE stream cannot be associated with one. The [MCP Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server) explains that the server must either return `Content-Type: text/event-stream` on a `GET` to the MCP endpoint, or return `HTTP 405 Method Not Allowed` to indicate it does not offer an SSE stream at this endpoint. Currently, `handleStreamRequest` returns `400 No sessionId` instead, only valid for stateful servers that do issue session ID.

This PR fixes that, when `stateless: true` and the `GET` arrives without an Mcp-Session-Id, it returns `405   Method Not Allowed`.

This affects connecting stateless servers to Cursor, as Cursor's MCP client follows the spec strictly: opens a long-lived `GET /mcp` with `Accept: text/event-stream`. That `GET` gets `400 Bad Request: No sessionId`, which Cursor treats as a _transport_ error rather than notifying that it's not SSE-ready. It then enters an infinite reconnect loop, visible in Cursor's logs as:

```                                                                     
  [error] Streamable HTTP error: Failed to open SSE stream: Bad Request
  [warning] [V1] connected -> error
  [error] Failed to reconnect SSE stream: Streamable HTTP error: Failed to open SSE stream: Bad Request
  [error] Maximum reconnection attempts (2) exceeded.
  [info] Re-initializing connection after session termination
  ... loops forever
``` 