### PR TITLE
feat: add --corsAddAllowedHeader CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ options:
 - `--sslKey`: Private keys filename in PEM format
 - `--tunnel`: Expose the proxy via a public tunnel (see [Public Tunnel](#public-tunnel))
 - `--tunnelSubdomain`: Request a specific subdomain for the tunnel (availability not guaranteed)
+- `--corsAddAllowedHeader`: Add a header name to `Access-Control-Allow-Headers` (defaults preserved). Repeat to add multiple. Useful when running with `--apiKey` so browser preflights for `X-API-Key` succeed.
 
 ### Public Tunnel
 
@@ -317,6 +318,23 @@ await startHTTPServer({
   },
 });
 ```
+
+#### CLI: adding allowed headers
+
+The CLI exposes a single `--corsAddAllowedHeader` flag that appends to the
+default `Access-Control-Allow-Headers` list (defaults preserved). The most
+common use is unblocking the browser preflight for a custom auth header when
+the proxy is started with `--apiKey`:
+
+```bash
+npx mcp-proxy --port 8080 --apiKey secret \
+  --corsAddAllowedHeader X-API-Key \
+  -- npx -y @modelcontextprotocol/server-filesystem /srv
+```
+
+Repeat the flag to add more (`--corsAddAllowedHeader X-API-Key --corsAddAllowedHeader X-Other`).
+For broader CORS overrides (origin allowlist, wildcard headers, disabling CORS),
+use the programmatic `cors` option below.
 
 #### Migration from Older Versions
 

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -55,6 +55,12 @@ const argv = await yargs(hideBin(process.argv))
         "The timeout (in milliseconds) for initial connection to the MCP server (default: 60 seconds)",
       type: "number",
     },
+    corsAddAllowedHeader: {
+      array: true,
+      describe:
+        "Add a header name to Access-Control-Allow-Headers (defaults preserved). Repeat to add multiple, e.g. `--corsAddAllowedHeader X-API-Key`.",
+      type: "string",
+    },
     debug: {
       default: false,
       describe: "Enable debug logging",
@@ -137,6 +143,22 @@ const argv = await yargs(hideBin(process.argv))
   .help()
   .parseAsync();
 
+// Default Access-Control-Allow-Headers list — must stay in sync with
+// `defaultCorsOptions.allowedHeaders` in src/startHTTPServer.ts.
+const DEFAULT_ALLOWED_HEADERS = [
+  "Content-Type",
+  "Authorization",
+  "Accept",
+  "Mcp-Session-Id",
+  "Mcp-Protocol-Version",
+  "Last-Event-Id",
+];
+
+const corsOption =
+  argv.corsAddAllowedHeader && argv.corsAddAllowedHeader.length > 0
+    ? { allowedHeaders: [...DEFAULT_ALLOWED_HEADERS, ...argv.corsAddAllowedHeader] }
+    : undefined;
+
 // If -- separator was used, everything after -- is the command and its args
 const dashDashArgs = argv["--"] as string[] | undefined;
 
@@ -218,6 +240,7 @@ const proxy = async () => {
 
   const server = await startHTTPServer({
     apiKey: argv.apiKey,
+    cors: corsOption,
     createServer,
     eventStore: new InMemoryEventStore(),
     host: argv.host,


### PR DESCRIPTION
## Summary

Adds a single `--corsAddAllowedHeader` CLI flag that appends header names to `Access-Control-Allow-Headers` (defaults preserved). Repeatable.

## Motivation

When `mcp-proxy` is started with `--apiKey`, the proxy expects the secret in the `X-API-Key` header. 

Browser-based apps (e.g. chat UIs) that support frontend-fetched streamable HTTP MCPs issue a CORS preflight for that header, and because `X-API-Key` is not in the default `Access-Control-Allow-Headers` list, the preflight is rejected. The `--apiKey` gate is therefore unreachable from a browser-hosted client.

The library already exposes a programmatic `cors.allowedHeaders` option that solves this, but it requires users to abandon the `npx mcp-proxy ...` one-liner and write a small Node wrapper. The README's "Common Use Cases" section explicitly calls this out as a known browser CORS friction point.

## What this changes

- New CLI flag `--corsAddAllowedHeader <name>` (yargs `array: true`, repeatable). Internally builds `cors: { allowedHeaders: [...defaults, ...added] }` and passes it to `startHTTPServer`.
- Defaults are preserved by hard-coding the default list in the CLI; a comment notes the source of truth in `src/startHTTPServer.ts`. 
- Behavior is opt-in

## Example

\`\`\`bash
npx mcp-proxy --port 8080 --apiKey secret \\
  --corsAddAllowedHeader X-API-Key \\
  -- npx -y @modelcontextprotocol/server-filesystem /srv
\`\`\`

## Test plan

- [x] \`pnpm test\` (vitest + tsc + eslint + jsr dry-run) — 87 passing, no new failures. Existing CORS tests in \`startHTTPServer.test.ts\` already cover the \`allowedHeaders: string[]\` code path used here, so no new test file was added.
- [x] \`pnpm build\` — clean.
- [x] Manual: \`OPTIONS http://127.0.0.1:8080/mcp\` with \`Access-Control-Request-Headers: x-api-key, content-type\` returns \`Access-Control-Allow-Headers: Content-Type, Authorization, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id, X-API-Key\`, and an end-to-end browser MCP client (\`proxyMode=frontend\`) successfully authenticates with \`--apiKey\`.

## Notes

Perhaps we should also make this a default (always accept X-API-Key when --apiKey is given), but not sure the maintainer's opinion on the security implications. 