### PR TITLE
fix: do not crash on a malformed request target

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -667,6 +667,36 @@ it("does not require auth for /ping endpoint", async () => {
   await httpServer.close();
 });
 
+it("responds with 400 to a malformed request target instead of crashing", async () => {
+  const port = await getRandomPort();
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server({ name: "test", version: "1.0.0" }, { capabilities: {} });
+    },
+    port,
+  });
+
+  // `//` is not a valid URL target; sent via http.request so it isn't
+  // normalized away. Before the fix this threw inside the request listener
+  // and crashed the process.
+  const statusCode = await new Promise<number>((resolve, reject) => {
+    const request = http.request(
+      { host: "localhost", path: "//", port },
+      (res) => {
+        res.resume();
+        resolve(res.statusCode ?? 0);
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+
+  expect(statusCode).toBe(400);
+
+  await httpServer.close();
+});
+
 it("does not require auth for OPTIONS requests", async () => {
   const port = await getRandomPort();
   const apiKey = "test-api-key-999";

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -951,7 +951,15 @@ export const startHTTPServer = async <T extends ServerLike>({
     // and would otherwise short-circuit the MCP protocol handlers.
     // Use a fixed base because `host` may be "::" (IPv6 any), which is not a
     // valid URL authority. We only need pathname here.
-    const requestUrl = new URL(req.url || "", "http://localhost");
+    // A malformed request target (e.g. "//") makes `new URL` throw, which
+    // would crash the process from this listener, so reject it with 400.
+    let requestUrl: URL;
+    try {
+      requestUrl = new URL(req.url || "", "http://localhost");
+    } catch {
+      res.writeHead(400).end("Bad Request");
+      return;
+    }
     const isMcpEndpoint =
       (sseEndpoint && requestUrl.pathname === sseEndpoint) ||
       (streamEndpoint && requestUrl.pathname === streamEndpoint);


### PR DESCRIPTION
**Fixes #66**

A request with a malformed target such as `//` crashes the Node process: the top-level `requestListener` calls `new URL(req.url || "", "http://localhost")` unconditionally, and `new URL("//", "http://localhost")` throws `ERR_INVALID_URL`. The throw escapes the listener (no try/catch), taking down the process — the reporter hit a prod restart-loop.

**Fix:** wrap that `new URL(...)` in a try/catch and respond with `400 Bad Request` on a parse failure. The other `new URL(req.url!, ...)` calls (lines ~347/681/729/788) all run inside handlers reached only *after* this guard, so guarding this one site is sufficient.

**Test:** added a test that sends `//` via `http.request` (so it isn't URL-normalized) and asserts a `400`. Verified before the fix it throws `TypeError: Invalid URL { input: '//' }` and hangs the request; after the fix it returns 400. Full `startHTTPServer` suite passes (39/39), `tsc` and `eslint` clean.
