### PR TITLE
docs: add Xquik stdio bridge example

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,27 @@ await startStdioServer({
 });
 ```
 
+To bridge a hosted streamable HTTP server into stdio, choose
+`ServerType.HTTPStream` and pass any required client headers through
+`transportOptions`. For example, Xquik exposes a hosted MCP endpoint for X data
+workflows:
+
+```ts
+import { ServerType, startStdioServer } from "mcp-proxy";
+
+await startStdioServer({
+  serverType: ServerType.HTTPStream,
+  transportOptions: {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${process.env.XQUIK_API_KEY}`,
+      },
+    },
+  },
+  url: "https://xquik.com/mcp",
+});
+```
+
 #### `tapTransport`
 
 Taps into a transport and logs events.


### PR DESCRIPTION
## Summary

- Add a startStdioServer example for hosted streamable HTTP MCP servers.
- Use Xquik's hosted MCP endpoint to show ServerType.HTTPStream with request headers.
- Keep the example near the existing startStdioServer docs.

## Validation

- git diff --check
- Checked Xquik's public MCP manifest for endpoint, transport, and auth header details.
