### PR TITLE
fix: return 401 for authenticated session failures

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -926,6 +926,136 @@ it("accepts requests with valid Bearer token in stateless mode", async () => {
   await stdioClient.close();
 });
 
+it("returns 401 for authenticated stream requests without a session ID", async () => {
+  const port = await getRandomPort();
+  const authenticate = vi.fn().mockResolvedValue({ userId: "test-user" });
+  const createServer = vi.fn(async () => {
+    return new Server({ name: "test", version: "1.0.0" }, { capabilities: {} });
+  });
+
+  const httpServer = await startHTTPServer({
+    authenticate,
+    createServer,
+    port,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "tools/list",
+      }),
+      headers: {
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer valid-token",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+
+    const errorResponse = (await response.json()) as {
+      error: { code: number; message: string };
+      id: null | number;
+      jsonrpc: string;
+    };
+    expect(errorResponse.error).toEqual({
+      code: -32000,
+      message: "Unauthorized: No valid session ID provided",
+    });
+    expect(errorResponse.id).toBe(1);
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(createServer).not.toHaveBeenCalled();
+  } finally {
+    await httpServer.close();
+  }
+});
+
+it("returns 401 for authenticated stream GET requests without a session ID", async () => {
+  const port = await getRandomPort();
+  const authenticate = vi.fn().mockResolvedValue({ userId: "test-user" });
+
+  const httpServer = await startHTTPServer({
+    authenticate,
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    port,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      headers: {
+        Accept: "text/event-stream",
+        Authorization: "Bearer valid-token",
+      },
+      method: "GET",
+    });
+
+    expect(response.status).toBe(401);
+
+    const errorResponse = (await response.json()) as {
+      error: { code: number; message: string };
+      id: null | number;
+      jsonrpc: string;
+    };
+    expect(errorResponse.error.message).toBe(
+      "Unauthorized: No valid session ID provided",
+    );
+    expect(errorResponse.id).toBeNull();
+    expect(authenticate).not.toHaveBeenCalled();
+  } finally {
+    await httpServer.close();
+  }
+});
+
+it("keeps malformed authenticated stream requests as 400", async () => {
+  const port = await getRandomPort();
+  const authenticate = vi.fn().mockResolvedValue({ userId: "test-user" });
+
+  const httpServer = await startHTTPServer({
+    authenticate,
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    port,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      body: JSON.stringify({ malformed: true }),
+      headers: {
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer valid-token",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+
+    const errorResponse = (await response.json()) as {
+      error: { code: number; message: string };
+      id: null | number;
+      jsonrpc: string;
+    };
+    expect(errorResponse.error.message).toBe(
+      "Bad Request: No valid session ID provided",
+    );
+    expect(authenticate).toHaveBeenCalledTimes(1);
+  } finally {
+    await httpServer.close();
+  }
+});
+
 it("returns 401 when authenticate callback returns null in stateless mode", async () => {
   const stdioTransport = new StdioClientTransport({
     args: ["src/fixtures/simple-stdio-server.ts"],

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -4,7 +4,10 @@ import {
   EventStore,
   StreamableHTTPServerTransport,
 } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import {
+  isInitializeRequest,
+  JSONRPCMessageSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import fs from "fs";
 import http from "http";
 import https from "https";
@@ -58,6 +61,35 @@ const createJsonRpcErrorResponse = (code: number, message: string) => {
     id: null,
     jsonrpc: "2.0",
   });
+};
+
+type SessionUnauthorizedResponseOptions = {
+  readonly body?: unknown;
+  readonly oauth?: AuthConfig["oauth"];
+  readonly res: http.ServerResponse;
+};
+
+const getRequestId = (body: unknown): unknown => {
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    Array.isArray(body) ||
+    !("id" in body)
+  ) {
+    return null;
+  }
+
+  return body.id;
+};
+
+const isJsonRpcMessage = (message: unknown): boolean => {
+  return JSONRPCMessageSchema.safeParse(message).success;
+};
+
+const isJsonRpcBody = (body: unknown): boolean => {
+  return Array.isArray(body)
+    ? body.every(isJsonRpcMessage)
+    : isJsonRpcMessage(body);
 };
 
 // Helper function to get WWW-Authenticate header value
@@ -121,6 +153,35 @@ const getWWWAuthenticateHeader = (
   }
 
   return `Bearer ${params.join(", ")}`;
+};
+
+const sendSessionUnauthorizedResponse = ({
+  body,
+  oauth,
+  res,
+}: SessionUnauthorizedResponseOptions): void => {
+  const message = "Unauthorized: No valid session ID provided";
+
+  res.setHeader("Content-Type", "application/json");
+
+  const wwwAuthHeader = getWWWAuthenticateHeader(oauth, {
+    error: "invalid_token",
+    error_description: message,
+  });
+  if (wwwAuthHeader) {
+    res.setHeader("WWW-Authenticate", wwwAuthHeader);
+  }
+
+  res.writeHead(401).end(
+    JSON.stringify({
+      error: {
+        code: -32000,
+        message,
+      },
+      id: getRequestId(body),
+      jsonrpc: "2.0",
+    }),
+  );
 };
 
 // Helper function to detect scope challenge errors
@@ -351,9 +412,9 @@ const handleStreamRequest = async <T extends ServerLike>({
       // In stateless mode, ignore session ID header entirely (like Python MCP SDK)
       const sessionId = stateless
         ? undefined
-        : (Array.isArray(req.headers["mcp-session-id"])
-            ? req.headers["mcp-session-id"][0]
-            : req.headers["mcp-session-id"]);
+        : Array.isArray(req.headers["mcp-session-id"])
+          ? req.headers["mcp-session-id"][0]
+          : req.headers["mcp-session-id"];
 
       let transport: StreamableHTTPServerTransport;
 
@@ -447,6 +508,12 @@ const handleStreamRequest = async <T extends ServerLike>({
       if (sessionId) {
         const activeTransport = activeTransports[sessionId];
         if (!activeTransport) {
+          if (authenticate && isJsonRpcBody(body)) {
+            sendSessionUnauthorizedResponse({ body, oauth, res });
+
+            return true;
+          }
+
           res.setHeader("Content-Type", "application/json");
           res
             .writeHead(404)
@@ -632,6 +699,12 @@ const handleStreamRequest = async <T extends ServerLike>({
 
         return true;
       } else {
+        if (authenticate && isJsonRpcBody(body)) {
+          sendSessionUnauthorizedResponse({ body, oauth, res });
+
+          return true;
+        }
+
         // Error if the server is not created but the request is not an initialize request
         res.setHeader("Content-Type", "application/json");
 
@@ -688,10 +761,16 @@ const handleStreamRequest = async <T extends ServerLike>({
         }
       | undefined = sessionId ? activeTransports[sessionId] : undefined;
 
-    if (!sessionId) {  
+    if (!sessionId) {
       // Return METHOD_NOT_ALLOWED so stateless clients' transport stops reconnecting
       if (stateless) {
         res.writeHead(405, { Allow: "POST" }).end("Method Not Allowed");
+
+        return true;
+      }
+
+      if (authenticate) {
+        sendSessionUnauthorizedResponse({ oauth, res });
 
         return true;
       }
@@ -702,6 +781,12 @@ const handleStreamRequest = async <T extends ServerLike>({
     }
 
     if (!activeTransport) {
+      if (authenticate) {
+        sendSessionUnauthorizedResponse({ oauth, res });
+
+        return true;
+      }
+
       res.writeHead(400).end("No active transport");
 
       return true;
@@ -733,6 +818,12 @@ const handleStreamRequest = async <T extends ServerLike>({
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
     if (!sessionId) {
+      if (authenticate) {
+        sendSessionUnauthorizedResponse({ oauth, res });
+
+        return true;
+      }
+
       res.writeHead(400).end("Invalid or missing sessionId");
 
       return true;
@@ -743,6 +834,12 @@ const handleStreamRequest = async <T extends ServerLike>({
     const activeTransport = activeTransports[sessionId];
 
     if (!activeTransport) {
+      if (authenticate) {
+        sendSessionUnauthorizedResponse({ oauth, res });
+
+        return true;
+      }
+
       res.writeHead(400).end("No active transport");
       return true;
     }
@@ -1020,7 +1117,7 @@ export const startHTTPServer = async <T extends ServerLike>({
     res.writeHead(404).end();
   };
 
-  let httpServer;
+  let httpServer: http.Server | https.Server;
   if (sslCa || sslCert || sslKey) {
     const options: https.ServerOptions = {};
     if (sslCa) {


### PR DESCRIPTION
## Summary
- Return JSON-RPC HTTP 401 for authenticated stream requests without a valid MCP session ID.
- Preserve existing 400 handling for malformed JSON-RPC request bodies.
- Add regression coverage for authenticated POST/GET session-ID failures.

Fixes punkpeye/fastmcp#180. FastMCP delegates this HTTP stream session handling to mcp-proxy, so the root fix belongs here.

## Tests
- `PATH="$PWD/node_modules/.bin:$PATH" ./node_modules/.bin/vitest run src/startHTTPServer.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/startHTTPServer.ts src/startHTTPServer.test.ts`
- Manual HTTP QA: `curl -i -X POST /mcp` with `Authorization` and no `Mcp-Session-Id` returned `HTTP/1.1 401 Unauthorized` with JSON-RPC error `Unauthorized: No valid session ID provided`.

Note: I also ran `./node_modules/.bin/vitest run`; on this machine it fails in unrelated `src/startStdioServer.test.ts` tests because both exceed the existing 5000 ms timeout. The same file times out when run alone.