### PR TITLE
Fix stream session keep-alive timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ options:
 - `--port`: Specify the port to listen on (default: 8080)
 - `--connectionTimeout`: Timeout in milliseconds for the initial connection to the MCP server (default: 60000, which is 60 seconds)
 - `--requestTimeout`: Timeout in milliseconds for requests to the MCP server (default: 300000, which is 5 minutes)
+- `--keepAliveTimeout`: HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 300000, which is 5 minutes)
 - `--debug`: Enable debug logging
 - `--shell`: Spawn the server via the user's shell
 - `--apiKey`: API key for authenticating requests (uses X-API-Key header)
@@ -430,6 +431,7 @@ Options:
 - `eventStore`: Event store for streamable HTTP transport (optional)
 - `port`: Port number to listen on
 - `host`: Host to bind to (default: "::")
+- `keepAliveTimeout`: HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 300000)
 - `sseEndpoint`: SSE endpoint path (default: "/sse", set to null to disable)
 - `streamEndpoint`: Streamable HTTP endpoint path (default: "/mcp", set to null to disable)
 - `stateless`: Enable stateless mode for HTTP streamable transport (default: false)

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -80,6 +80,12 @@ const argv = await yargs(hideBin(process.argv))
       describe: "The host to listen on",
       type: "string",
     },
+    keepAliveTimeout: {
+      default: 300000,
+      describe:
+        "The HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 5 minutes)",
+      type: "number",
+    },
     port: {
       default: 8080,
       describe: "The port to listen on",
@@ -244,6 +250,7 @@ const proxy = async () => {
     createServer,
     eventStore: new InMemoryEventStore(),
     host: argv.host,
+    keepAliveTimeout: argv.keepAliveTimeout,
     port: argv.port,
     sseEndpoint:
       argv.server && argv.server !== "sse"

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -131,6 +131,73 @@ it("proxies messages between HTTP stream and stdio servers", async () => {
   expect(onClose).toHaveBeenCalled();
 });
 
+it(
+  "keeps stateful HTTP stream sessions alive after idle keep-alive timeout window",
+  async () => {
+    const port = await getRandomPort();
+    const onClose = vi.fn().mockResolvedValue(undefined);
+
+    const httpServer = await startHTTPServer({
+      createServer: async () => {
+        return new Server(
+          { name: "test", version: "1.0.0" },
+          { capabilities: {} },
+        );
+      },
+      onClose,
+      port,
+    });
+
+    const initializeResponse = await fetch(`http://localhost:${port}/mcp`, {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+          protocolVersion: "2025-03-26",
+        },
+      }),
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(initializeResponse.status).toBe(200);
+    const sessionId = initializeResponse.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    await initializeResponse.text();
+
+    await delay(6_000);
+
+    const listToolsResponse = await fetch(`http://localhost:${port}/mcp`, {
+      body: JSON.stringify({
+        id: 2,
+        jsonrpc: "2.0",
+        method: "tools/list",
+        params: {},
+      }),
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "mcp-session-id": sessionId!,
+      },
+      method: "POST",
+    });
+    const listToolsBody = await listToolsResponse.text();
+
+    expect(listToolsResponse.status).not.toBe(404);
+    expect(listToolsBody).not.toContain("Session not found");
+    expect(onClose).not.toHaveBeenCalled();
+
+    await httpServer.close();
+  },
+  15_000,
+);
+
 it("proxies messages between SSE and stdio servers", async () => {
   const stdioTransport = new StdioClientTransport({
     args: ["src/fixtures/simple-stdio-server.ts"],

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -13,6 +13,8 @@ import { randomUUID } from "node:crypto";
 import { AuthConfig, AuthenticationMiddleware } from "./authentication.js";
 import { InMemoryEventStore } from "./InMemoryEventStore.js";
 
+const DEFAULT_KEEP_ALIVE_TIMEOUT = 300_000;
+
 export interface CorsOptions {
   allowedHeaders?: string | string[]; // Allow string[] or '*' for wildcard
   credentials?: boolean;
@@ -881,6 +883,7 @@ export const startHTTPServer = async <T extends ServerLike>({
   enableJsonResponse,
   eventStore,
   host = "::",
+  keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT,
   oauth,
   onClose,
   onConnect,
@@ -900,6 +903,7 @@ export const startHTTPServer = async <T extends ServerLike>({
   enableJsonResponse?: boolean;
   eventStore?: EventStore;
   host?: string;
+  keepAliveTimeout?: number;
   oauth?: AuthConfig["oauth"];
   onClose?: (server: T) => Promise<void>;
   onConnect?: (server: T) => Promise<void>;
@@ -1054,6 +1058,14 @@ export const startHTTPServer = async <T extends ServerLike>({
   } else {
     httpServer = http.createServer(requestListener);
   }
+
+  // Keep stateful stream sessions from being torn down when Node closes
+  // otherwise-idle HTTP keep-alive sockets after its 5 second default.
+  httpServer.keepAliveTimeout = keepAliveTimeout;
+  httpServer.headersTimeout = Math.max(
+    httpServer.headersTimeout,
+    keepAliveTimeout + 1000,
+  );
 
   await new Promise((resolve) => {
     httpServer.listen(port, host, () => {


### PR DESCRIPTION
## Summary
- Keep stateful HTTP stream sessions alive past Node.js default 5s keep-alive socket timeout.
- Add a configurable `keepAliveTimeout` option for `startHTTPServer` and the CLI.
- Add regression coverage for an initialized stream session surviving a 6s idle window.
- Document the new option.

Fixes #57

## Why
After the SDK bump, stateful stream sessions could be destroyed when Node closed an otherwise-idle keep-alive connection after 5 seconds, causing follow-up requests with a valid `Mcp-Session-Id` to fail with `Session not found`.

## Changes
- Default HTTP `keepAliveTimeout` is now 300000ms.
- `headersTimeout` is kept at least 1000ms above the configured keep-alive timeout.
- `--keepAliveTimeout` wires through the CLI.
- README documents both CLI and programmatic usage.

## Validation
- `PATH=/tmp/stealtheye-external/mcp-proxy/node_modules/.bin:$PATH ./node_modules/.bin/vitest run src/startHTTPServer.test.ts` — 40 tests passed
- `npx -p node@22 -p pnpm@9 pnpm run build` — passed
- `npx -p node@22 -p pnpm@9 pnpm exec tsc --noEmit` — passed
- `npx -p node@22 -p pnpm@9 pnpm exec eslint src/startHTTPServer.ts src/startHTTPServer.test.ts` — passed
- `npx -p node@22 -p pnpm@9 pnpm exec eslint ./src/bin/mcp-proxy.ts` — passed
- `npx -p node@22 -p pnpm@9 pnpm run test` — 6 test files / 89 tests passed, plus tsc, eslint, and JSR dry-run
