### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Proxy
 
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fmcp-proxy%2Fpunkpeye.svg)](https://mcptoplist.com/server/mcp.so%2Fmcp-proxy%2Fpunkpeye)
+
 A TypeScript streamable HTTP and SSE proxy for [MCP](https://modelcontextprotocol.io/) servers that use `stdio` transport.
 
 > [!NOTE]


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,919 MCP servers across the major
registries, and **MCP Proxy MCP Server** is currently ranked **#919**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fmcp-proxy%2Fpunkpeye.svg)](https://mcptoplist.com/server/mcp.so%2Fmcp-proxy%2Fpunkpeye)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building MCP Proxy MCP Server!
