### PR TITLE
fix: check headersSent before writing SSE connect error response

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -2672,3 +2672,54 @@ it("enables a bounded, per-session resumability event store by default", async (
     await httpServer.close();
   }
 });
+
+it("does not crash when the SSE connect error path runs after headers are sent", async () => {
+  // Regression test: the catch block of the SSE connect path called
+  // res.writeHead(500) without checking res.headersSent. When the failure
+  // happened after the SSE stream was established (headers already sent),
+  // writeHead threw ERR_HTTP_HEADERS_SENT, the request listener rejected,
+  // and the process died on the unhandled rejection.
+  const port = await getRandomPort();
+
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    // server.connect() and the initial transport.send() succeed, so the
+    // SSE 200 headers are already on the wire when this throws.
+    onConnect: async () => {
+      throw new Error("simulated connect failure");
+    },
+    port,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/sse`);
+    expect(response.status).toBe(200);
+
+    // Wait until the error path has run, then give any rejection a tick.
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[mcp-proxy] error connecting to server",
+        expect.any(Error),
+      );
+    });
+    await delay(100);
+
+    expect(unhandledRejections).toEqual([]);
+  } finally {
+    await httpServer.close();
+    consoleError.mockRestore();
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+});

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -958,7 +958,9 @@ const handleSSERequest = async <T extends ServerLike>({
       if (!closed) {
         console.error("[mcp-proxy] error connecting to server", error);
 
-        res.writeHead(500).end("Error connecting to server");
+        if (!res.headersSent) {
+          res.writeHead(500).end("Error connecting to server");
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

The SSE connect error path in `handleSSERequest` calls `res.writeHead(500)`
without checking `res.headersSent`. If anything in that `try` block throws
after the SSE stream is established — `server.connect()` failing after
`transport.start()`, the initial `transport.send()`, or the `onConnect()`
hook — the 200 headers are already on the wire, so `writeHead` throws
`ERR_HTTP_HEADERS_SENT`. That exception rejects the async request listener
and the process dies on the unhandled rejection.

## Root cause

`src/startHTTPServer.ts`, catch block of the SSE GET handler:

```ts
} catch (error) {
  if (!closed) {
    console.error("[mcp-proxy] error connecting to server", error);

    res.writeHead(500).end("Error connecting to server");
  }
}
```

`closed` only tracks the response `close` event; it does not say whether
headers were already sent. By the time this catch runs, `transport.start()`
(called from `server.connect()`) has normally already written the 200 + SSE
headers, so the `writeHead(500)` throws.

The DELETE handler in the same file already guards the identical pattern
(line 878):

```ts
if (!res.headersSent) {
  res.writeHead(500).end("Error handling delete request");
}
```

This PR mirrors that guard in the SSE connect catch.

## Reproduction

Standalone script run with `tsx` against `main`: start the HTTP server with
an `onConnect` hook that throws, then open the SSE stream. `server.connect()`
and the initial `transport.send()` succeed, so headers are sent before the
hook throws.

On `main` (e298da8):

```
[mcp-proxy] error connecting to server Error: simulated connect failure
UNHANDLED REJECTION: Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:407:11)
    at handleSSERequest (.../src/startHTTPServer.ts:961:13) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
EXIT CODE: 1
```

With the fix:

```
[mcp-proxy] error connecting to server Error: simulated connect failure
SSE response status: 200
PROCESS STILL ALIVE — no crash
EXIT CODE: 0
```

The error is still logged exactly as before; only the impossible `writeHead`
is skipped.

## Fix

```diff
       if (!closed) {
         console.error("[mcp-proxy] error connecting to server", error);
 
-        res.writeHead(500).end("Error connecting to server");
+        if (!res.headersSent) {
+          res.writeHead(500).end("Error connecting to server");
+        }
       }
```

## Regression test

One test added to `src/startHTTPServer.test.ts`
("does not crash when the SSE connect error path runs after headers are
sent"). It listens for `process.on("unhandledRejection")`, triggers the path
with a throwing `onConnect`, and asserts no rejection arrives.

Without the fix:

```
 FAIL  ... > does not crash when the SSE connect error path runs after headers are sent
AssertionError: expected [ …(1) ] to deeply equal []
+ [
+   Error {
+     "message": "Cannot write headers after they are sent to the client",
+     "code": "ERR_HTTP_HEADERS_SENT",
+   },
+ ]
 Tests  1 failed | 45 skipped (46)
```

With the fix: `Tests  1 passed | 45 skipped (46)`.

## Verification

- `vitest run` — all 46 tests in `src/startHTTPServer.test.ts` pass. Full
  suite: 98/100; the 2 failures are pre-existing 5s timeouts in
  `src/startStdioServer.test.ts` in my Windows environment and fail
  identically on unmodified `main` (that file does not import the module
  touched here).
- `tsc` — clean.
- `eslint .` — clean.
- `jsr publish --dry-run --allow-dirty` — "Success Dry run complete".

I found this reading the SSE code path and reproduced it locally with the
script above; it is not a production incident report.

Scope note: when headers were already sent I simply skip the 500 and leave
the stream alone — cleanup then happens through the existing
`res.on("close")` handler when the client disconnects, same as on the DELETE
path. Happy to also tear the transport down in that branch if you prefer.

The stream POST catch (~line 766) has the same writeHead-after-error shape.
I left it untouched to keep this diff minimal; happy to look at it as a
follow-up if you're interested.

_Disclosure: I used an AI coding assistant while preparing this change. I
found no contribution policy in the repo requiring disclosure, so I am
noting it voluntarily. Every output quoted above was captured by me against
`main` @ e298da8._
