### PR TITLE
fix: compare API key in constant time

### DIFF
--- a/src/authentication.test.ts
+++ b/src/authentication.test.ts
@@ -57,6 +57,22 @@ describe("AuthenticationMiddleware", () => {
       expect(middleware.validateRequest(req)).toBe(false);
     });
 
+    it("should reject same-length API key with different content", () => {
+      const middleware = new AuthenticationMiddleware({ apiKey });
+      const req = createMockRequest({ "x-api-key": "test-api-key-124" });
+
+      expect(middleware.validateRequest(req)).toBe(false);
+    });
+
+    it("should reject API keys of arbitrary length without throwing", () => {
+      const middleware = new AuthenticationMiddleware({ apiKey });
+      const shortReq = createMockRequest({ "x-api-key": "a" });
+      const longReq = createMockRequest({ "x-api-key": "a".repeat(1024) });
+
+      expect(middleware.validateRequest(shortReq)).toBe(false);
+      expect(middleware.validateRequest(longReq)).toBe(false);
+    });
+
     it("should reject empty API key", () => {
       const middleware = new AuthenticationMiddleware({ apiKey });
       const req = createMockRequest({ "x-api-key": "" });

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage } from "http";
 
+import { timingSafeEqual } from "node:crypto";
+
 export interface AuthConfig {
   apiKey?: string;
   oauth?: {
@@ -148,6 +150,8 @@ export class AuthenticationMiddleware {
       return false;
     }
 
-    return apiKey === this.config.apiKey;
+    const expected = Buffer.from(this.config.apiKey);
+    const actual = Buffer.from(apiKey);
+    return actual.length === expected.length && timingSafeEqual(actual, expected);
   }
 }


### PR DESCRIPTION
## Summary

`AuthenticationMiddleware.validateRequest` matched the `X-API-Key` header against the configured key with `===` (`src/authentication.ts:151`), a variable-time string comparison that returns on the first differing byte. Same class as the JWT/consent comparisons fixed in fastmcp (CWE-208); this is the only credential comparison of that shape in the repo (filtered sweep of `===`/`!==` over key/token/secret/auth — everything else is type guards).

## Fix

Route the comparison through `crypto.timingSafeEqual` with a length guard:

```ts
const expected = Buffer.from(this.config.apiKey);
const actual = Buffer.from(apiKey);
return actual.length === expected.length && timingSafeEqual(actual, expected);
```

The guard is required, not optional: `timingSafeEqual` throws `RangeError` on different-length buffers — the existing `should reject incorrect API key` test (9-char vs 16-char key) demonstrates it (red with the naive fix, green with the guard). Behavior is unchanged: valid keys authorize, wrong keys return `false`, and the empty/non-string header cases still short-circuit before the comparison.

## Tests

Two new cases in the existing `X-API-Key validation` describe (same `createMockRequest` style):

- same length, different content (`test-api-key-124`) → `false` — exercises the full constant-time path;
- arbitrary lengths (`"a"`, 1024 chars) → `false` without throwing — exercises the guard.

A unit test can't assert constant-time behavior; what these cover is the guard's behavior and the constant-time code path — the timing claim itself rests on `crypto.timingSafeEqual`.

## Verification (Windows, Node v24.14.1)

- `src/authentication.test.ts`: **39/39** pass. Adversarial cycle: naive fix without the guard fails with `RangeError` on the pre-existing wrong-length test; full fix green; revert to `===` also green (public behavior identical); re-apply green.
- `tsc`: clean · `eslint .`: clean · `jsr publish --dry-run --allow-dirty`: Success.
- Full `vitest run`: 78/102 — the 24 failures are **pre-existing environment failures on this Windows host** (proxyServer/startHTTPServer/startStdioServer spawn/port timeouts); the identical set reproduces on clean `main` (baseline compared), and `authentication.test.ts` is 39/39 in both.

AI-assisted: drafted with AI assistance and verified locally as above.