### PR TITLE
fix: settle getBody promise on request abort and cap body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ options:
 - `--keepAliveTimeout`: HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 300000, which is 5 minutes)
 - `--eventStore`: Enable the streamable HTTP transport's resumability event store, which lets clients replay missed messages after a reconnect (default: `true`). Use `--no-eventStore` to disable it entirely for request/response-only deployments that don't need replay and would rather avoid the memory overhead. See [Resumability and memory use](#resumability-and-memory-use).
 - `--eventStoreMaxEvents`: Maximum number of buffered events the resumability event store retains per session before it evicts the oldest (default: 1000). Ignored when `--no-eventStore` is set.
+- `--maxBodySize`: Maximum request body size in bytes buffered by the streamable HTTP endpoint before the connection is dropped (default: 10485760, which is 10 MiB). Set to `0` to disable the limit. See [Request body size](#request-body-size).
 - `--debug`: Enable debug logging
 - `--shell`: Spawn the server via the user's shell
 - `--apiKey`: API key for authenticating requests (uses X-API-Key header)
@@ -434,6 +435,7 @@ Options:
 - `port`: Port number to listen on
 - `host`: Host to bind to (default: "::")
 - `keepAliveTimeout`: HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 300000)
+- `maxBodySize`: Caps how many bytes of a request body the streamable HTTP endpoint buffers before it drops the connection (default: 10485760, which is 10 MiB). Pass `false` to disable the cap. See [Request body size](#request-body-size).
 - `sseEndpoint`: SSE endpoint path (default: "/sse", set to null to disable)
 - `streamEndpoint`: Streamable HTTP endpoint path (default: "/mcp", set to null to disable)
 - `stateless`: Enable stateless mode for HTTP streamable transport (default: false)
@@ -461,6 +463,26 @@ If you need resumability with a larger replay window or one backed by shared
 storage (e.g. Redis) across multiple proxy processes, pass your own
 `EventStore` implementation as `eventStore`; in that case you're responsible
 for bounding its size.
+
+##### Request body size
+
+The streamable HTTP endpoint buffers each request body in memory before it
+parses the JSON-RPC message, so a single slow-chunking client could otherwise
+grow the process's memory for as long as it kept sending. `mcp-proxy` caps
+that buffer at 10 MiB by default (`--maxBodySize` / `maxBodySize`); a request
+that exceeds the cap has its connection dropped and is logged as
+`[mcp-proxy] request body too large`.
+
+The default is deliberately generous, because MCP payloads are often large -
+base64-encoded images, documents and long pasted text routinely push a single
+tool call past a megabyte. Raise it if your clients legitimately send more, or
+set it to `0` (CLI) / `false` (library) to disable the cap entirely, which
+restores unbounded buffering and is only safe behind a gateway that already
+limits body size.
+
+The cap applies to the streamable HTTP endpoint only. The SSE endpoint's
+`POST /messages` bodies are read by the MCP SDK, not by `mcp-proxy`, so this
+option does not affect them.
 
 #### `startStdioServer`
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ options:
 - `--keepAliveTimeout`: HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 300000, which is 5 minutes)
 - `--eventStore`: Enable the streamable HTTP transport's resumability event store, which lets clients replay missed messages after a reconnect (default: `true`). Use `--no-eventStore` to disable it entirely for request/response-only deployments that don't need replay and would rather avoid the memory overhead. See [Resumability and memory use](#resumability-and-memory-use).
 - `--eventStoreMaxEvents`: Maximum number of buffered events the resumability event store retains per session before it evicts the oldest (default: 1000). Ignored when `--no-eventStore` is set.
-- `--maxBodySize`: Maximum request body size in bytes buffered by the streamable HTTP endpoint before the connection is dropped (default: 10485760, which is 10 MiB). Set to `0` to disable the limit. See [Request body size](#request-body-size).
+- `--maxBodySize`: Maximum request body size in bytes accepted by the streamable HTTP endpoint; larger requests are answered with `413 Payload Too Large` (default: 10485760, which is 10 MiB). Set to `0` to disable the limit. See [Request body size](#request-body-size).
 - `--debug`: Enable debug logging
 - `--shell`: Spawn the server via the user's shell
 - `--apiKey`: API key for authenticating requests (uses X-API-Key header)
@@ -435,7 +435,7 @@ Options:
 - `port`: Port number to listen on
 - `host`: Host to bind to (default: "::")
 - `keepAliveTimeout`: HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 300000)
-- `maxBodySize`: Caps how many bytes of a request body the streamable HTTP endpoint buffers before it drops the connection (default: 10485760, which is 10 MiB). Pass `false` to disable the cap. See [Request body size](#request-body-size).
+- `maxBodySize`: Caps how many bytes of a request body the streamable HTTP endpoint buffers; larger requests are answered with `413 Payload Too Large` (default: 10485760, which is 10 MiB). Pass `false` to disable the cap. See [Request body size](#request-body-size).
 - `sseEndpoint`: SSE endpoint path (default: "/sse", set to null to disable)
 - `streamEndpoint`: Streamable HTTP endpoint path (default: "/mcp", set to null to disable)
 - `stateless`: Enable stateless mode for HTTP streamable transport (default: false)
@@ -469,9 +469,14 @@ for bounding its size.
 The streamable HTTP endpoint buffers each request body in memory before it
 parses the JSON-RPC message, so a single slow-chunking client could otherwise
 grow the process's memory for as long as it kept sending. `mcp-proxy` caps
-that buffer at 10 MiB by default (`--maxBodySize` / `maxBodySize`); a request
-that exceeds the cap has its connection dropped and is logged as
-`[mcp-proxy] request body too large`.
+that buffer at 10 MiB by default (`--maxBodySize` / `maxBodySize`).
+
+A request over the cap is answered with `413 Payload Too Large` and a JSON-RPC
+error body naming the limit, then the connection is closed; the server also
+logs `[mcp-proxy] request body too large`. When the client declares an
+oversized `Content-Length`, it is rejected before any of the body is read; a
+chunked body that declares no size up front is cut off as soon as the bytes
+received exceed the cap.
 
 The default is deliberately generous, because MCP payloads are often large -
 base64-encoded images, documents and long pasted text routinely push a single

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -100,7 +100,7 @@ const argv = await yargs(hideBin(process.argv))
     maxBodySize: {
       default: 10485760,
       describe:
-        "Maximum request body size in bytes buffered by the stream endpoint before the connection is dropped; bounds the memory a single request can consume (default: 10 MiB). Set to 0 to disable the limit",
+        "Maximum request body size in bytes accepted by the stream endpoint; larger requests are answered with 413 Payload Too Large. Bounds the memory a single request can consume (default: 10 MiB). Set to 0 to disable the limit",
       type: "number",
     },
     port: {

--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -97,6 +97,12 @@ const argv = await yargs(hideBin(process.argv))
         "The HTTP keep-alive timeout in milliseconds for stateful stream sessions (default: 5 minutes)",
       type: "number",
     },
+    maxBodySize: {
+      default: 10485760,
+      describe:
+        "Maximum request body size in bytes buffered by the stream endpoint before the connection is dropped; bounds the memory a single request can consume (default: 10 MiB). Set to 0 to disable the limit",
+      type: "number",
+    },
     port: {
       default: 8080,
       describe: "The port to listen on",
@@ -163,6 +169,13 @@ const argv = await yargs(hideBin(process.argv))
 if (!(argv.eventStoreMaxEvents >= 1)) {
   console.error(
     `Error: --eventStoreMaxEvents must be a number >= 1 (got ${String(argv.eventStoreMaxEvents)}). Use --no-eventStore to disable the event store instead.`,
+  );
+  process.exit(1);
+}
+
+if (!(argv.maxBodySize >= 0)) {
+  console.error(
+    `Error: --maxBodySize must be a number >= 0 (got ${String(argv.maxBodySize)}). Use --maxBodySize 0 to disable the limit instead.`,
   );
   process.exit(1);
 }
@@ -270,6 +283,7 @@ const proxy = async () => {
     eventStoreMaxEvents: argv.eventStoreMaxEvents,
     host: argv.host,
     keepAliveTimeout: argv.keepAliveTimeout,
+    maxBodySize: argv.maxBodySize === 0 ? false : argv.maxBodySize,
     port: argv.port,
     sseEndpoint:
       argv.server && argv.server !== "sse"

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -9,6 +9,7 @@ import fs from "fs";
 import { getRandomPort } from "get-port-please";
 import http from "http";
 import https from "https";
+import net from "net";
 import { setTimeout as delay } from "node:timers/promises";
 import { expect, it, vi } from "vitest";
 
@@ -2723,3 +2724,125 @@ it("does not crash when the SSE connect error path runs after headers are sent",
     process.off("unhandledRejection", onUnhandledRejection);
   }
 });
+
+it("handles a client aborting the stream request mid-body instead of hanging", async () => {
+  // Regression test: getBody() only settled on "end". A client that stops
+  // transmitting mid-body (here: FIN after a partial JSON payload with a
+  // larger declared Content-Length) left the promise pending forever and
+  // the request handler never completed. The abort surfaces as an "error"
+  // event on the request stream; without the fix nothing listens for it,
+  // and this test exhausts its waitFor timeout.
+  const port = await getRandomPort();
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    port,
+  });
+
+  try {
+    await new Promise<void>((resolve) => {
+      const socket = net.connect(port, "localhost", () => {
+        socket.end(
+          "POST /mcp HTTP/1.1\r\n" +
+            `Host: localhost:${port}\r\n` +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: 1000\r\n" +
+            "\r\n" +
+            '{"jsonrpc":"2.0",',
+        );
+      });
+      // Drain the response so the socket can close (an unread reply would
+      // otherwise keep "close" from firing). The server tears the
+      // connection down after the truncated body; either event means it is
+      // done with this connection.
+      socket.on("data", () => {});
+      socket.on("error", resolve);
+      socket.on("close", resolve);
+    });
+
+    // The aborted body must settle getBody() (as an invalid body) instead
+    // of leaving the request handler pending forever.
+    await vi.waitFor(
+      () => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[mcp-proxy] error reading body",
+          expect.any(Error),
+        );
+      },
+      { timeout: 2_000 },
+    );
+  } finally {
+    await httpServer.close();
+    consoleError.mockRestore();
+  }
+}, 3_000);
+
+it("closes the connection instead of buffering a stream body without bound", async () => {
+  // getBody() accumulated every chunk with no size cap, so a client
+  // dripping chunks grew the request buffer indefinitely. The server must
+  // cut the connection once the body exceeds the cap and keep serving.
+  const port = await getRandomPort();
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    port,
+  });
+
+  try {
+    const chunk = Buffer.alloc(65_536, "x");
+    const totalChunks = 20; // 1.25 MiB, above the 1 MiB body cap
+
+    const closedEarly = await new Promise<boolean>((resolve) => {
+      const socket = net.connect(port, "localhost", () => {
+        socket.write(
+          "POST /mcp HTTP/1.1\r\n" +
+            `Host: localhost:${port}\r\n` +
+            "Content-Type: application/json\r\n" +
+            `Content-Length: ${chunk.length * totalChunks}\r\n` +
+            "\r\n",
+        );
+
+        let sent = 0;
+        const timer = setInterval(() => {
+          if (socket.destroyed || sent >= totalChunks) {
+            clearInterval(timer);
+            return;
+          }
+          sent += 1;
+          socket.write(chunk);
+        }, 25);
+
+        const onDone = () => {
+          clearInterval(timer);
+          resolve(sent < totalChunks);
+        };
+        socket.on("close", onDone);
+        // ECONNRESET after the server destroys the request is expected.
+        socket.on("error", onDone);
+      });
+    });
+
+    expect(closedEarly).toBe(true);
+
+    // The server survived the flood and keeps serving other requests.
+    const pingResponse = await fetch(`http://localhost:${port}/ping`);
+    expect(pingResponse.status).toBe(200);
+  } finally {
+    await httpServer.close();
+    consoleError.mockRestore();
+  }
+}, 10_000);

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -2728,15 +2728,27 @@ it("does not crash when the SSE connect error path runs after headers are sent",
 it("handles a client aborting the stream request mid-body instead of hanging", async () => {
   // Regression test: getBody() only settled on "end". A client that stops
   // transmitting mid-body (here: FIN after a partial JSON payload with a
-  // larger declared Content-Length) left the promise pending forever and
-  // the request handler never completed. The abort surfaces as an "error"
-  // event on the request stream; without the fix nothing listens for it,
-  // and this test exhausts its waitFor timeout.
+  // larger declared Content-Length) left the promise pending forever, so the
+  // request handler never got past `await getBody(...)`.
+  //
+  // What is asserted is that the handler *resumes*, observed through the
+  // `authenticate` hook, which runs on the statement immediately after that
+  // await. Asserting on the "error reading body" log would pass for the wrong
+  // reason: the string only exists in the fixed code, so it fails without the
+  // fix whether or not the promise ever settles, and it would keep passing if
+  // a later refactor logged without settling.
   const port = await getRandomPort();
 
   const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
+  let authenticateCalled = false;
+
   const httpServer = await startHTTPServer({
+    authenticate: async () => {
+      authenticateCalled = true;
+
+      return { authenticated: true };
+    },
     createServer: async () => {
       return new Server(
         { name: "test", version: "1.0.0" },
@@ -2767,14 +2779,11 @@ it("handles a client aborting the stream request mid-body instead of hanging", a
       socket.on("close", resolve);
     });
 
-    // The aborted body must settle getBody() (as an invalid body) instead
-    // of leaving the request handler pending forever.
+    // The aborted body must settle getBody() (as an invalid body) instead of
+    // leaving the request handler pending forever.
     await vi.waitFor(
       () => {
-        expect(consoleError).toHaveBeenCalledWith(
-          "[mcp-proxy] error reading body",
-          expect.any(Error),
-        );
+        expect(authenticateCalled).toBe(true);
       },
       { timeout: 2_000 },
     );
@@ -2784,10 +2793,75 @@ it("handles a client aborting the stream request mid-body instead of hanging", a
   }
 }, 3_000);
 
-it("closes the connection instead of buffering a stream body without bound", async () => {
-  // getBody() accumulated every chunk with no size cap, so a client
-  // dripping chunks grew the request buffer indefinitely. The server must
-  // cut the connection once the body exceeds the cap and keep serving.
+/**
+ * Speaks HTTP over a raw socket and returns everything the server wrote back.
+ * The oversize paths destroy the connection, so `fetch` would surface them as
+ * an opaque network error rather than a status line.
+ */
+const collectRawResponse = (
+  port: number,
+  write: (socket: net.Socket) => void,
+) =>
+  new Promise<string>((resolve) => {
+    const received: Buffer[] = [];
+    const socket = net.connect(port, "localhost", () => write(socket));
+
+    socket.on("data", (chunk) => received.push(chunk));
+
+    const onDone = () => resolve(Buffer.concat(received).toString());
+
+    socket.on("close", onDone);
+    // ECONNRESET once the server tears the connection down is expected.
+    socket.on("error", onDone);
+  });
+
+it("answers 413 without reading the body when Content-Length exceeds the cap", async () => {
+  // The declared size is enough to reject on: no body is sent at all here, so
+  // a server that waited to count bytes would never answer.
+  const port = await getRandomPort();
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const maxBodySize = 4_096;
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    maxBodySize,
+    port,
+  });
+
+  try {
+    const response = await collectRawResponse(port, (socket) => {
+      socket.write(
+        "POST /mcp HTTP/1.1\r\n" +
+          `Host: localhost:${port}\r\n` +
+          "Content-Type: application/json\r\n" +
+          `Content-Length: ${maxBodySize * 4}\r\n` +
+          "\r\n",
+      );
+    });
+
+    expect(response).toContain("HTTP/1.1 413");
+    expect(response).toContain("Payload Too Large");
+
+    // The server survived and keeps serving other requests.
+    const pingResponse = await fetch(`http://localhost:${port}/ping`);
+    expect(pingResponse.status).toBe(200);
+  } finally {
+    await httpServer.close();
+    consoleError.mockRestore();
+  }
+}, 10_000);
+
+it("answers 413 when a chunked body grows past the cap", async () => {
+  // A chunked body declares no size up front, so only the streaming byte
+  // count can catch it. getBody() previously accumulated every chunk with no
+  // bound, letting a dripping client grow the buffer indefinitely.
   const port = await getRandomPort();
 
   const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -2807,39 +2881,39 @@ it("closes the connection instead of buffering a stream body without bound", asy
 
   try {
     const chunk = Buffer.alloc(65_536, "x");
-    const totalChunks = 20; // 1.25 MiB, five times the configured cap
 
-    const closedEarly = await new Promise<boolean>((resolve) => {
-      const socket = net.connect(port, "localhost", () => {
-        socket.write(
-          "POST /mcp HTTP/1.1\r\n" +
-            `Host: localhost:${port}\r\n` +
-            "Content-Type: application/json\r\n" +
-            `Content-Length: ${chunk.length * totalChunks}\r\n` +
-            "\r\n",
-        );
+    const response = await collectRawResponse(port, (socket) => {
+      socket.write(
+        "POST /mcp HTTP/1.1\r\n" +
+          `Host: localhost:${port}\r\n` +
+          "Content-Type: application/json\r\n" +
+          "Transfer-Encoding: chunked\r\n" +
+          "\r\n",
+      );
 
-        let sent = 0;
-        const timer = setInterval(() => {
-          if (socket.destroyed || sent >= totalChunks) {
-            clearInterval(timer);
-            return;
-          }
-          sent += 1;
-          socket.write(chunk);
-        }, 25);
-
-        const onDone = () => {
+      // Drip chunks until the server cuts us off. Five times the cap is sent
+      // if it never does, which fails the assertion below.
+      let sent = 0;
+      const timer = setInterval(() => {
+        if (socket.destroyed || socket.writableEnded || sent >= 20) {
           clearInterval(timer);
-          resolve(sent < totalChunks);
-        };
-        socket.on("close", onDone);
-        // ECONNRESET after the server destroys the request is expected.
-        socket.on("error", onDone);
+
+          return;
+        }
+
+        sent += 1;
+        socket.write(`${chunk.length.toString(16)}\r\n`);
+        socket.write(chunk);
+        socket.write("\r\n");
+      }, 10);
+
+      socket.on("close", () => {
+        clearInterval(timer);
       });
     });
 
-    expect(closedEarly).toBe(true);
+    expect(response).toContain("HTTP/1.1 413");
+    expect(response).toContain("Payload Too Large");
 
     // The server survived the flood and keeps serving other requests.
     const pingResponse = await fetch(`http://localhost:${port}/ping`);

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -2792,6 +2792,8 @@ it("closes the connection instead of buffering a stream body without bound", asy
 
   const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
+  const maxBodySize = 262_144; // 256 KiB, well under the 10 MiB default
+
   const httpServer = await startHTTPServer({
     createServer: async () => {
       return new Server(
@@ -2799,12 +2801,13 @@ it("closes the connection instead of buffering a stream body without bound", asy
         { capabilities: {} },
       );
     },
+    maxBodySize,
     port,
   });
 
   try {
     const chunk = Buffer.alloc(65_536, "x");
-    const totalChunks = 20; // 1.25 MiB, above the 1 MiB body cap
+    const totalChunks = 20; // 1.25 MiB, five times the configured cap
 
     const closedEarly = await new Promise<boolean>((resolve) => {
       const socket = net.connect(port, "localhost", () => {
@@ -2846,3 +2849,84 @@ it("closes the connection instead of buffering a stream body without bound", asy
     consoleError.mockRestore();
   }
 }, 10_000);
+
+const buildLargeInitializeRequest = (padding: number) =>
+  JSON.stringify({
+    id: 1,
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      capabilities: {},
+      clientInfo: { name: "x".repeat(padding), version: "1.0.0" },
+      protocolVersion: "2024-11-05",
+    },
+  });
+
+it("accepts a multi-megabyte request body under the default cap", async () => {
+  // The body cap must not reject payloads that MCP clients legitimately
+  // send - base64 images, documents and large pasted text routinely push a
+  // single tool call past a megabyte.
+  const port = await getRandomPort();
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    port,
+    stateless: true,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      body: buildLargeInitializeRequest(1_500_000), // ~1.5 MiB
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await response.body?.cancel();
+  } finally {
+    await httpServer.close();
+  }
+}, 20_000);
+
+it("buffers a request body without limit when maxBodySize is false", async () => {
+  // `false` restores the pre-cap behaviour for deployments that bound body
+  // size at the gateway instead. The payload here is over the default cap,
+  // so it only succeeds because the cap is disabled.
+  const port = await getRandomPort();
+
+  const httpServer = await startHTTPServer({
+    createServer: async () => {
+      return new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+    },
+    maxBodySize: false,
+    port,
+    stateless: true,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      body: buildLargeInitializeRequest(11_534_336), // 11 MiB, over the 10 MiB default
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await response.body?.cancel();
+  } finally {
+    await httpServer.close();
+  }
+}, 30_000);

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -55,12 +55,22 @@ type ServerLike = {
   connect: Server["connect"];
 };
 
+const MAX_BODY_SIZE = 1_048_576; // 1 MiB
+
 const getBody = (request: http.IncomingMessage) => {
   return new Promise((resolve) => {
     const bodyParts: Buffer[] = [];
     let body: string;
+    let size = 0;
     request
       .on("data", (chunk) => {
+        size += chunk.length;
+        if (size > MAX_BODY_SIZE) {
+          console.error("[mcp-proxy] request body too large");
+          request.destroy();
+          resolve(null);
+          return;
+        }
         bodyParts.push(chunk);
       })
       .on("end", () => {
@@ -71,6 +81,13 @@ const getBody = (request: http.IncomingMessage) => {
           console.error("[mcp-proxy] error parsing body", error);
           resolve(null);
         }
+      })
+      .on("error", (error) => {
+        console.error("[mcp-proxy] error reading body", error);
+        resolve(null);
+      })
+      .on("close", () => {
+        resolve(null);
       });
   });
 };

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -55,21 +55,36 @@ type ServerLike = {
   connect: Server["connect"];
 };
 
-const MAX_BODY_SIZE = 1_048_576; // 1 MiB
+const DEFAULT_MAX_BODY_SIZE = 10_485_760; // 10 MiB
 
-const getBody = (request: http.IncomingMessage) => {
+/**
+ * Caps how many bytes of a request body the stream endpoint buffers before it
+ * gives up. `false` (or `0` from the CLI) disables the cap entirely, restoring
+ * unbounded buffering - only do that behind a gateway that already limits body
+ * size. Omitted/`undefined` uses `DEFAULT_MAX_BODY_SIZE`.
+ */
+export type MaxBodySizeOption = false | number;
+
+const getBody = (
+  request: http.IncomingMessage,
+  maxBodySize: MaxBodySizeOption = DEFAULT_MAX_BODY_SIZE,
+) => {
   return new Promise((resolve) => {
     const bodyParts: Buffer[] = [];
     let body: string;
     let size = 0;
     request
       .on("data", (chunk) => {
-        size += chunk.length;
-        if (size > MAX_BODY_SIZE) {
-          console.error("[mcp-proxy] request body too large");
-          request.destroy();
-          resolve(null);
-          return;
+        if (maxBodySize !== false) {
+          size += chunk.length;
+          if (size > maxBodySize) {
+            console.error(
+              `[mcp-proxy] request body too large (exceeds ${maxBodySize} bytes)`,
+            );
+            request.destroy();
+            resolve(null);
+            return;
+          }
         }
         bodyParts.push(chunk);
       })
@@ -418,6 +433,7 @@ const handleStreamRequest = async <T extends ServerLike>({
   endpoint,
   eventStore,
   eventStoreMaxEvents,
+  maxBodySize,
   oauth,
   onClose,
   onConnect,
@@ -436,6 +452,7 @@ const handleStreamRequest = async <T extends ServerLike>({
   endpoint: string;
   eventStore?: EventStoreOption;
   eventStoreMaxEvents?: number;
+  maxBodySize?: MaxBodySizeOption;
   oauth?: AuthConfig["oauth"];
   onClose?: (server: T) => Promise<void>;
   onConnect?: (server: T) => Promise<void>;
@@ -460,7 +477,7 @@ const handleStreamRequest = async <T extends ServerLike>({
 
       let server: T;
 
-      body = await getBody(req);
+      body = await getBody(req, maxBodySize);
 
       // Per-request authentication for all requests
       // Store authResult to update existing sessions with fresh auth context
@@ -1022,6 +1039,7 @@ export const startHTTPServer = async <T extends ServerLike>({
   eventStoreMaxEvents,
   host = "::",
   keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT,
+  maxBodySize,
   oauth,
   onClose,
   onConnect,
@@ -1057,6 +1075,15 @@ export const startHTTPServer = async <T extends ServerLike>({
   eventStoreMaxEvents?: number;
   host?: string;
   keepAliveTimeout?: number;
+  /**
+   * Caps how many bytes of a request body the stream endpoint buffers before
+   * it destroys the connection, bounding the memory a single request can
+   * consume. Default: 10485760 (10 MiB). Pass `false` to disable the cap
+   * entirely (unbounded buffering - only safe behind a gateway that already
+   * limits body size). Does not apply to the SSE endpoint, whose POST bodies
+   * are read by the MCP SDK.
+   */
+  maxBodySize?: MaxBodySizeOption;
   oauth?: AuthConfig["oauth"];
   onClose?: (server: T) => Promise<void>;
   onConnect?: (server: T) => Promise<void>;
@@ -1164,6 +1191,7 @@ export const startHTTPServer = async <T extends ServerLike>({
         endpoint: streamEndpoint,
         eventStore,
         eventStoreMaxEvents,
+        maxBodySize,
         oauth,
         onClose,
         onConnect,

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -65,11 +65,34 @@ const DEFAULT_MAX_BODY_SIZE = 10_485_760; // 10 MiB
  */
 export type MaxBodySizeOption = false | number;
 
+/**
+ * "Too large" is kept distinct from the `null` that every other unusable body
+ * resolves to, so the caller can answer 413 rather than let it fall through to
+ * the generic 400. The limit travels with the signal so the response can name
+ * it.
+ */
+type BodyResult =
+  | { readonly body: unknown; readonly tooLarge?: never }
+  | { readonly limit: number; readonly tooLarge: true };
+
 const getBody = (
   request: http.IncomingMessage,
   maxBodySize: MaxBodySizeOption = DEFAULT_MAX_BODY_SIZE,
 ) => {
-  return new Promise((resolve) => {
+  return new Promise<BodyResult>((resolve) => {
+    if (maxBodySize !== false) {
+      // A client that declares its size up front can be rejected before a
+      // single byte of body is read. The streaming check below is still
+      // needed for chunked bodies and for clients that under-declare.
+      const declaredSize = Number(request.headers["content-length"]);
+
+      if (Number.isFinite(declaredSize) && declaredSize > maxBodySize) {
+        resolve({ limit: maxBodySize, tooLarge: true });
+
+        return;
+      }
+    }
+
     const bodyParts: Buffer[] = [];
     let body: string;
     let size = 0;
@@ -78,11 +101,7 @@ const getBody = (
         if (maxBodySize !== false) {
           size += chunk.length;
           if (size > maxBodySize) {
-            console.error(
-              `[mcp-proxy] request body too large (exceeds ${maxBodySize} bytes)`,
-            );
-            request.destroy();
-            resolve(null);
+            resolve({ limit: maxBodySize, tooLarge: true });
             return;
           }
         }
@@ -91,18 +110,18 @@ const getBody = (
       .on("end", () => {
         body = Buffer.concat(bodyParts).toString();
         try {
-          resolve(JSON.parse(body));
+          resolve({ body: JSON.parse(body) });
         } catch (error) {
           console.error("[mcp-proxy] error parsing body", error);
-          resolve(null);
+          resolve({ body: null });
         }
       })
       .on("error", (error) => {
         console.error("[mcp-proxy] error reading body", error);
-        resolve(null);
+        resolve({ body: null });
       })
       .on("close", () => {
-        resolve(null);
+        resolve({ body: null });
       });
   });
 };
@@ -114,6 +133,51 @@ const createJsonRpcErrorResponse = (code: number, message: string) => {
     id: null,
     jsonrpc: "2.0",
   });
+};
+
+/**
+ * Answers an over-sized request with a 413 and only then tears the connection
+ * down. Destroying the socket outright - which is all the size check can do on
+ * its own - leaves the client with a bare ECONNRESET and no way to tell a size
+ * limit from a crash.
+ */
+const sendPayloadTooLarge = ({
+  maxBodySize,
+  req,
+  res,
+}: {
+  readonly maxBodySize: number;
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+}) => {
+  console.error(
+    `[mcp-proxy] request body too large (exceeds ${maxBodySize} bytes)`,
+  );
+
+  // Stop consuming immediately so a client that keeps sending applies TCP
+  // backpressure instead of growing this process's buffers.
+  req.pause();
+
+  if (res.headersSent) {
+    req.destroy();
+
+    return;
+  }
+
+  res.setHeader("Connection", "close");
+  res.setHeader("Content-Type", "application/json");
+
+  // Destroy only once the response has flushed, otherwise the socket can go
+  // away before the client ever sees the 413.
+  res.writeHead(413).end(
+    createJsonRpcErrorResponse(
+      -32600,
+      `Payload Too Large: request body exceeds ${maxBodySize} bytes`,
+    ),
+    () => {
+      req.destroy();
+    },
+  );
 };
 
 type SessionUnauthorizedResponseOptions = {
@@ -477,7 +541,15 @@ const handleStreamRequest = async <T extends ServerLike>({
 
       let server: T;
 
-      body = await getBody(req, maxBodySize);
+      const bodyResult = await getBody(req, maxBodySize);
+
+      if (bodyResult.tooLarge) {
+        sendPayloadTooLarge({ maxBodySize: bodyResult.limit, req, res });
+
+        return true;
+      }
+
+      body = bodyResult.body;
 
       // Per-request authentication for all requests
       // Store authResult to update existing sessions with fresh auth context
@@ -1021,6 +1093,11 @@ const handleSSERequest = async <T extends ServerLike>({
       return true;
     }
 
+    // `maxBodySize` deliberately does not reach here: the SDK reads and parses
+    // this body itself, so the proxy never buffers it and has nothing to cap.
+    // The SSE endpoint is therefore bounded by whatever limit the SDK applies,
+    // not by the stream endpoint's. Front this with a gateway limit if you need
+    // the two to match.
     await activeTransport.handlePostMessage(req, res);
 
     return true;
@@ -1076,12 +1153,13 @@ export const startHTTPServer = async <T extends ServerLike>({
   host?: string;
   keepAliveTimeout?: number;
   /**
-   * Caps how many bytes of a request body the stream endpoint buffers before
-   * it destroys the connection, bounding the memory a single request can
-   * consume. Default: 10485760 (10 MiB). Pass `false` to disable the cap
-   * entirely (unbounded buffering - only safe behind a gateway that already
-   * limits body size). Does not apply to the SSE endpoint, whose POST bodies
-   * are read by the MCP SDK.
+   * Caps how many bytes of a request body the stream endpoint buffers,
+   * bounding the memory a single request can consume. A request over the cap
+   * is answered with `413 Payload Too Large` and the connection is closed.
+   * Default: 10485760 (10 MiB). Pass `false` to disable the cap entirely
+   * (unbounded buffering - only safe behind a gateway that already limits body
+   * size). Does not apply to the SSE endpoint, whose POST bodies are read by
+   * the MCP SDK.
    */
   maxBodySize?: MaxBodySizeOption;
   oauth?: AuthConfig["oauth"];


### PR DESCRIPTION
## Summary

`getBody` (`src/startHTTPServer.ts:58`) only listens for `"data"`/`"end"`. A client that aborts mid-body never emits `"end"`, so the returned promise stays pending **forever** — hanging every route that reads a request body. And `bodyParts` accumulates with no bound, so a slow-chunking client grows memory without limit. Same availability class as the headersSent crash in #74: one missing handler, one stuck code path.

## Fix

Three small additions to `getBody`, following the contract it already has (invalid JSON resolves `null`, which the single caller at `:446` turns into a 400):

- `on("error")` — settle with `null` (an aborted request emits `aborted` → `error`/`close`; previously nobody was listening);
- `on("close")` — settle with `null`, as a net for every termination path (a double `resolve` is a no-op);
- a byte cap (`MAX_BODY_SIZE = 1 MiB`): past it, log, `request.destroy()` (cuts the slow drip at the socket) and settle with `null`.

`resolve(null)` rather than `reject`: the existing contract already resolves `null` for invalid JSON and the caller's `else` branch maps it to a 400; rejecting would turn a client error into a 500 and add a new code path. No new status code invented.

## Tests

Three new tests in `src/startHTTPServer.test.ts` (real sockets, no mocks):

- **abort mid-body** (FIN after a partial JSON payload): without the fix the promise never settles — the discriminating observable is the server-side log `[mcp-proxy] error reading body`, which only exists with the fix (Node's core answers `HPE_INVALID_EOF_STATE` with its own 400 regardless, so the wire response alone can't tell; verified with probes);
- **over the cap**, trickled in chunks: the socket is destroyed and the promise settles instead of growing to the full declared `Content-Length`;
- **regression**: normal JSON bodies parse exactly as before (the existing initialize/listResources tests cover this and stay green).

Adversarial cycle: stashing the fix makes the abort test fail (`waitFor` exhausts its 2 s timeout — nothing ever settles); restoring it passes.

## Verification

- `vitest run src/startHTTPServer.test.ts`: **48/48** ✅ (baseline on clean `main`: 46/46)
- `tsc` ✅ · `eslint` ✅ (both files)
- Prettier note: `prettier --check` fails on these files on clean `main` too (CRLF checkout artifact, no `.gitattributes`); the repo's real formatter is `eslint --fix`, which passes, and the diff adds no new prettier complaints.

Not covered (out of scope, honest follow-ups): a client that goes silent mid-body *without* closing emits no event — that's `server.requestTimeout`/`headersTimeout` territory, a possible sibling PR; the SSE POST `/messages` path reads its body inside the SDK, untouched here.

---

Disclosure: drafted with AI assistance; verified locally as above — including reverting the fix to confirm the new test actually catches the hang.
