### PR TITLE
fix: replay standalone GET stream events

### DIFF
--- a/src/InMemoryEventStore.test.ts
+++ b/src/InMemoryEventStore.test.ts
@@ -59,6 +59,38 @@ describe("InMemoryEventStore", () => {
     expect(replayedEvents[2].eventId).toBe(eventIds[4]);
   });
 
+  it("replays the standalone GET stream whose ID begins with an underscore", async () => {
+    const store = new InMemoryEventStore();
+    const streamId = "_GET_stream";
+    const firstMessage: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "notifications/tools/list_changed",
+    };
+    const secondMessage: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "notifications/resources/list_changed",
+    };
+
+    const firstEventId = await store.storeEvent(streamId, firstMessage);
+    const secondEventId = await store.storeEvent(streamId, secondMessage);
+    const replayedEvents: Array<{
+      eventId: string;
+      message: JSONRPCMessage;
+    }> = [];
+
+    const returnedStreamId = await store.replayEventsAfter(firstEventId, {
+      send: async (eventId, message) => {
+        replayedEvents.push({ eventId, message });
+      },
+    });
+
+    expect(returnedStreamId).toBe(streamId);
+    expect(replayedEvents).toEqual([
+      { eventId: secondEventId, message: secondMessage },
+    ]);
+    expect(await store.getStreamIdForEventId(firstEventId)).toBe(streamId);
+  });
+
   it("isolates events by stream ID and only replays events from the same stream", async () => {
     const store = new InMemoryEventStore();
     const streamId1 = "stream-alpha";

--- a/src/InMemoryEventStore.ts
+++ b/src/InMemoryEventStore.ts
@@ -56,6 +56,13 @@ export class InMemoryEventStore implements EventStore {
   }
 
   /**
+   * Gets the stream ID associated with a stored event ID.
+   */
+  async getStreamIdForEventId(eventId: string): Promise<string | undefined> {
+    return this.events.get(eventId)?.streamId;
+  }
+
+  /**
    * Replays events that occurred after a specific event ID
    * Implements EventStore.replayEventsAfter
    */
@@ -65,12 +72,11 @@ export class InMemoryEventStore implements EventStore {
       send,
     }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> },
   ): Promise<string> {
-    if (!lastEventId || !this.events.has(lastEventId)) {
+    if (!lastEventId) {
       return "";
     }
 
-    // Extract the stream ID from the event ID
-    const streamId = this.getStreamIdFromEventId(lastEventId);
+    const streamId = await this.getStreamIdForEventId(lastEventId);
 
     if (!streamId) {
       return "";
@@ -149,14 +155,5 @@ export class InMemoryEventStore implements EventStore {
     const random = Math.random().toString(36).substring(2, 5);
 
     return `${streamId}_${timestamp}_${counter}_${random}`;
-  }
-
-  /**
-   * Extracts the stream ID from an event ID
-   */
-  private getStreamIdFromEventId(eventId: string): string {
-    const parts = eventId.split("_");
-
-    return parts.length > 0 ? parts[0] : "";
   }
 }


### PR DESCRIPTION
## Summary

- Resolve replay streams from the event store's metadata instead of parsing the event ID.
- Implement the MCP SDK's optional `getStreamIdForEventId` lookup.
- Add a regression test for the standalone SSE stream ID `_GET_stream`.

## Problem

`InMemoryEventStore` previously recovered a stream ID with `eventId.split("_")[0]`. For the SDK's standalone SSE stream, an event ID starts with `_GET_stream_...`, so the parser returned an empty string. Replay then returned `""` instead of the original stream, skipped the later event, and could not preserve the resumed GET stream mapping.

The regression was written first and failed with:

```text
AssertionError: expected '' to be '_GET_stream'
```

The fix reads the stream ID from the metadata already stored alongside the event. It does not change the generated event ID format or accept new client input.

This is a local port of a known defect in the MCP TypeScript SDK example that this store follows; it is not presented as a novel upstream discovery. Relevant upstream history:

- https://github.com/modelcontextprotocol/typescript-sdk/issues/943
- https://github.com/modelcontextprotocol/typescript-sdk/issues/2560
- https://github.com/modelcontextprotocol/typescript-sdk/pull/1984
- https://github.com/modelcontextprotocol/typescript-sdk/pull/2044
- https://github.com/modelcontextprotocol/typescript-sdk/pull/2567

## Verification

- `vitest run src/InMemoryEventStore.test.ts`: 9/9 passed
- `tsc`: passed
- `eslint .`: passed
- `jsr publish --dry-run`: passed

The broader Windows run reached 167/168 tests after an external harness shim translated the repository tests' `spawn("tsx")` calls to the installed CLI. The one remaining failure is the pre-existing raw-socket test `answers 413 when a chunked body grows past the cap`, which receives an empty response on Windows. It reproduces independently and neither `startHTTPServer.ts` nor its test is touched here; this PR does not claim a fully green suite.

`pnpm install --frozen-lockfile` passed the configured minimum-release-age check, then stopped on pnpm's ignored-build policy for `esbuild` and `tldjs`. No build scripts or policy exceptions were approved, and no package, lockfile, or workspace configuration was changed. The gates above ran with the dependencies pnpm had already linked.
