### PR TITLE
fix: settle send() when the child process dies before stdin drains

### DIFF
--- a/src/StdioClientTransport.test.ts
+++ b/src/StdioClientTransport.test.ts
@@ -1,0 +1,126 @@
+import { JSONRPCMessage } from "@modelcontextprotocol/client";
+import { ChildProcess } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { expect, it } from "vitest";
+
+import { StdioClientTransport } from "./StdioClientTransport.js";
+
+/**
+ * Reaches for the child process the transport keeps private, so the test can
+ * watch the stdin stream the send path writes to.
+ */
+const childOf = (transport: StdioClientTransport): ChildProcess =>
+  (transport as unknown as { _process: ChildProcess })._process;
+
+const messageOfSize = (id: number, bytes: number): JSONRPCMessage => ({
+  id,
+  jsonrpc: "2.0",
+  method: "tools/call",
+  params: { arguments: { blob: "x".repeat(bytes) }, name: "noop" },
+});
+
+it("settles pending sends when the child exits before the write drains", async () => {
+  // Regression test: send() resolved on "drain" and nothing else. A child
+  // that stops reading stdin makes write() return false, and if that child
+  // then dies the "drain" event never arrives - so the promise stayed pending
+  // forever and its "drain" listener stayed attached, one per stuck send.
+  const transport = new StdioClientTransport({
+    // Never reads stdin, so the pipe backs up and write() returns false.
+    args: ["-e", "setTimeout(() => {}, 60000)"],
+    command: "node",
+    env: process.env as Record<string, string>,
+    stderr: "ignore",
+  });
+
+  await transport.start();
+
+  const child = childOf(transport);
+  const stdin = child.stdin!;
+  // spawn() attaches its own "exit" listener for the abort signal, so the
+  // interesting number is the delta, not the absolute count.
+  const exitListenersBefore = child.listenerCount("exit");
+
+  const outcomes = [1, 2, 3].map((id) =>
+    transport.send(messageOfSize(id, 1024 * 1024)).then(
+      () => "resolved" as const,
+      () => "rejected" as const,
+    ),
+  );
+
+  // Precondition: every write was buffered rather than flushed, which is the
+  // only situation the bug applies to. The promise executor runs
+  // synchronously, so the listeners are already attached here.
+  expect(stdin.writableLength).toBeGreaterThan(0);
+  expect(stdin.listenerCount("drain")).toBe(3);
+
+  process.kill(transport.pid!, "SIGKILL");
+
+  const settled = await Promise.race([
+    Promise.all(outcomes),
+    delay(2_000).then(() => "still pending" as const),
+  ]);
+
+  expect(settled).toEqual(["rejected", "rejected", "rejected"]);
+  expect(stdin.listenerCount("drain")).toBe(0);
+  expect(child.listenerCount("exit")).toBe(exitListenersBefore);
+
+  await transport.close();
+}, 10_000);
+
+it("settles a pending send when the transport is closed", async () => {
+  // The same hang on the ordinary shutdown path: close() aborts the child, so
+  // a write that has not drained yet can never complete.
+  const transport = new StdioClientTransport({
+    args: ["-e", "setTimeout(() => {}, 60000)"],
+    command: "node",
+    env: process.env as Record<string, string>,
+    stderr: "ignore",
+  });
+
+  await transport.start();
+
+  const stdin = childOf(transport).stdin!;
+
+  const outcome = transport.send(messageOfSize(1, 1024 * 1024)).then(
+    () => "resolved" as const,
+    () => "rejected" as const,
+  );
+
+  expect(stdin.listenerCount("drain")).toBe(1);
+
+  await transport.close();
+
+  await expect(
+    Promise.race([outcome, delay(2_000).then(() => "still pending" as const)]),
+  ).resolves.toBe("rejected");
+  expect(stdin.listenerCount("drain")).toBe(0);
+}, 10_000);
+
+it("resolves send() and leaves no listeners behind once a buffered write drains", async () => {
+  // The happy path for the same code: a child that does read stdin lets the
+  // buffered write flush, so "drain" arrives and the promise resolves - and
+  // the listeners added for the failure paths must be removed too.
+  const transport = new StdioClientTransport({
+    args: ["-e", "process.stdin.resume(); setTimeout(() => {}, 60000)"],
+    command: "node",
+    env: process.env as Record<string, string>,
+    stderr: "ignore",
+  });
+
+  await transport.start();
+
+  const child = childOf(transport);
+  const stdin = child.stdin!;
+  const exitListenersBefore = child.listenerCount("exit");
+
+  const send = transport.send(messageOfSize(1, 1024 * 1024));
+
+  expect(stdin.listenerCount("drain")).toBe(1);
+
+  await expect(send).resolves.toBeUndefined();
+
+  expect(stdin.listenerCount("drain")).toBe(0);
+  expect(child.listenerCount("exit")).toBe(exitListenersBefore);
+
+  await transport.close();
+}, 10_000);

--- a/src/StdioClientTransport.ts
+++ b/src/StdioClientTransport.ts
@@ -132,17 +132,51 @@ export class StdioClientTransport implements Transport {
   }
 
   send(message: JSONRPCMessage): Promise<void> {
-    return new Promise((resolve) => {
-      if (!this._process?.stdin) {
+    return new Promise((resolve, reject) => {
+      const child = this._process;
+
+      if (!child?.stdin) {
         throw new Error("Not connected");
       }
 
+      const stdin = child.stdin;
       const json = serializeMessage(message);
-      if (this._process.stdin.write(json)) {
+
+      if (stdin.write(json)) {
         resolve();
-      } else {
-        this._process.stdin.once("drain", resolve);
+
+        return;
       }
+
+      // The payload was buffered instead of flushed, so the write completes on
+      // "drain". That event never arrives if the pipe breaks or the child dies
+      // first, which would leave this promise pending forever and its "drain"
+      // listener attached - one per stuck send. Settle on every termination
+      // path and always detach.
+      const settle = (error?: Error) => {
+        child.off("exit", onExit);
+        stdin.off("close", onClose);
+        stdin.off("drain", onDrain);
+        stdin.off("error", onError);
+
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+
+      const onDrain = () => settle();
+      const onClose = () =>
+        settle(new Error("stdin closed before the message was sent"));
+      const onError = (error: Error) => settle(error);
+      const onExit = () =>
+        settle(new Error("Child process exited before the message was sent"));
+
+      child.once("exit", onExit);
+      stdin.once("close", onClose);
+      stdin.once("drain", onDrain);
+      stdin.once("error", onError);
     });
   }
 


### PR DESCRIPTION
## Problem

`StdioClientTransport.send()` only resolved on the stdin `"drain"` event. When `write()` returns
false because the child has stopped reading, and that child then exits or the pipe breaks,
`"drain"` never fires: the returned promise stays pending forever, and its `"drain"` listener stays
attached — one leaked listener per stuck `send()`.

## Fix

Also settle on stdin `"error"`/`"close"` and the child's `"exit"`, and remove every listener on
whichever path wins. A broken pipe now surfaces as a rejected `send()` instead of a silent hang.

## Tests

Adds `src/StdioClientTransport.test.ts` covering:

- a child that stops reading and is then killed → every pending `send()` rejects and no `"drain"`
  listeners leak;
- `close()` while a write is buffered → the pending `send()` rejects;
- the happy path → a buffered write drains, `send()` resolves, and no listeners are left behind.

### Verification

Reverting only the production change, with the new tests kept, turns them red:

```
FAIL  > settles pending sends when the child exits before the write drains
  AssertionError: expected 'still pending' to deeply equal [ 'rejected', 'rejected', 'rejected' ]
FAIL  > settles a pending send when the transport is closed
  AssertionError: expected 'still pending' to be 'rejected'
Test Files  1 failed (1)   |   Tests  2 failed | 1 passed (3)
```

Mutating the fix to resolve instead of reject on the failure paths also turns them red, so the
tests assert the specific rejection rather than any settlement:

```
FAIL  > settles a pending send when the transport is closed
  AssertionError: expected 'resolved' to be 'rejected'
```

An independent runtime probe using only Node built-ins, replicating the original and fixed `send()`:

```
[ORIGINAL] outcome=STILL-PENDING(hang)  drainListenersAfter=1
[FIXED   ] outcome=rejected             drainListenersAfter=0
[HAPPY   ] outcome=resolved             drainListenersAfter=0
```

With the fix: `vitest src/StdioClientTransport.test.ts` → 3 passed, `tsc` → exit 0, `eslint` on the
changed files → clean.

**Not verified:** the full suite is flaky on my Windows machine — the server tests `spawn('tsx', …)`
and fail with `spawn tsx ENOENT`. I checked this reproduces identically on a pristine `main`, so it
is environmental and pre-existing, not a regression from this change; none of the failing tests
touch `StdioClientTransport`. `jsr publish --dry-run` was also not run (it needs network/jsr).
