### PR TITLE
chore: reduce default keep-alive timeout to 60s

### DIFF
--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -28,7 +28,7 @@ import { randomUUID } from "node:crypto";
 import { AuthConfig, AuthenticationMiddleware } from "./authentication.js";
 import { InMemoryEventStore } from "./InMemoryEventStore.js";
 
-const DEFAULT_KEEP_ALIVE_TIMEOUT = 300_000;
+const DEFAULT_KEEP_ALIVE_TIMEOUT = 60_000;
 
 /**
  * How long a 2025-era stream session with nothing attached to it is kept before


### PR DESCRIPTION
Reduce default HTTP keep-alive timeout from 300s to 60s to free idle sockets and lower server resource usage. This is a conservative default change to improve performance under many concurrent connections; behavior is still configurable via the CLI option.