### PR TITLE
perf: avoid global sort on event replay

### DIFF
--- a/src/InMemoryEventStore.test.ts
+++ b/src/InMemoryEventStore.test.ts
@@ -333,6 +333,57 @@ describe("InMemoryEventStore", () => {
     expect(store.size).toBe(4);
   });
 
+  it("prunes the per-stream replay index in step with eviction", async () => {
+    // Replay walks a per-stream index instead of sorting the whole event map,
+    // so that index is a second structure that has to stay in step with the
+    // events it points at. Replay skips IDs it cannot resolve, which would hide
+    // a desync behind correct-looking output - so assert the index itself.
+    const store = new InMemoryEventStore({ maxEvents: 3 });
+    const index = (
+      store as unknown as { eventIdsByStream: Map<string, string[]> }
+    ).eventIdsByStream;
+    const streamId = "partially-evicted";
+
+    const eventIds: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      eventIds.push(
+        await store.storeEvent(streamId, {
+          id: i,
+          jsonrpc: "2.0",
+          method: `step/${i}`,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+
+    // The two evicted IDs are dropped from the index, and the survivors stay in
+    // insertion order - which is what replay relies on to pick up mid-stream.
+    expect(index.get(streamId)).toEqual(eventIds.slice(2));
+  });
+
+  it("drops the index entry for a stream whose events are all evicted", async () => {
+    // A stream accumulates one event per server->client message, so a long
+    // session opens many short-lived streams (#72). If a fully evicted stream
+    // kept its index entry, that map would grow without bound even though the
+    // event map itself stays capped.
+    const store = new InMemoryEventStore({ maxEvents: 2 });
+    const index = (
+      store as unknown as { eventIdsByStream: Map<string, string[]> }
+    ).eventIdsByStream;
+
+    for (let i = 0; i < 5; i++) {
+      await store.storeEvent(`stream-${i}`, {
+        id: i,
+        jsonrpc: "2.0",
+        method: `step/${i}`,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+
+    expect(store.size).toBe(2);
+    expect([...index.keys()]).toEqual(["stream-3", "stream-4"]);
+  });
+
   it("defaults to a bounded size when maxEvents is not configured", async () => {
     const store = new InMemoryEventStore();
     const streamId = "default-cap-stream";

--- a/src/InMemoryEventStore.ts
+++ b/src/InMemoryEventStore.ts
@@ -36,6 +36,12 @@ export class InMemoryEventStore implements EventStore {
   }
   private events: Map<string, { message: JSONRPCMessage; streamId: string }> =
     new Map();
+  /**
+   * Keeps event IDs in stream-local insertion order so replay can walk only the
+   * relevant stream instead of sorting the entire global event map on every
+   * reconnect.
+   */
+  private eventIdsByStream = new Map<string, string[]>();
   private lastTimestamp = 0;
   private lastTimestampCounter = 0;
 
@@ -69,38 +75,37 @@ export class InMemoryEventStore implements EventStore {
       return "";
     }
 
-    // Extract the stream ID from the event ID
     const streamId = this.getStreamIdFromEventId(lastEventId);
 
     if (!streamId) {
       return "";
     }
 
-    let foundLastEvent = false;
+    const eventIdsForStream = this.eventIdsByStream.get(streamId);
 
-    // Sort events by eventId for chronological ordering
-    const sortedEvents = [...this.events.entries()].sort((a, b) =>
-      a[0].localeCompare(b[0]),
-    );
+    if (!eventIdsForStream) {
+      return "";
+    }
 
-    for (const [
-      eventId,
-      { message, streamId: eventStreamId },
-    ] of sortedEvents) {
-      // Only include events from the same stream
-      if (eventStreamId !== streamId) {
+    const lastEventIndex = eventIdsForStream.indexOf(lastEventId);
+
+    if (lastEventIndex === -1) {
+      return "";
+    }
+
+    for (
+      let index = lastEventIndex + 1;
+      index < eventIdsForStream.length;
+      index++
+    ) {
+      const eventId = eventIdsForStream[index];
+      const storedEvent = this.events.get(eventId);
+
+      if (!storedEvent) {
         continue;
       }
 
-      // Start sending events after we find the lastEventId
-      if (eventId === lastEventId) {
-        foundLastEvent = true;
-        continue;
-      }
-
-      if (foundLastEvent) {
-        await send(eventId, message);
-      }
+      await send(eventId, storedEvent.message);
     }
 
     return streamId;
@@ -115,6 +120,10 @@ export class InMemoryEventStore implements EventStore {
 
     this.events.set(eventId, { message, streamId });
 
+    const streamEvents = this.eventIdsByStream.get(streamId) ?? [];
+    streamEvents.push(eventId);
+    this.eventIdsByStream.set(streamId, streamEvents);
+
     // Map iterates in insertion order, so the first key is always the
     // oldest surviving event - evicting it is a plain FIFO/ring buffer.
     while (this.events.size > this.maxEvents) {
@@ -124,7 +133,24 @@ export class InMemoryEventStore implements EventStore {
         break;
       }
 
+      const oldestEvent = this.events.get(oldestEventId);
       this.events.delete(oldestEventId);
+
+      if (oldestEvent) {
+        const streamEventIds = this.eventIdsByStream.get(oldestEvent.streamId);
+
+        if (streamEventIds) {
+          const index = streamEventIds.indexOf(oldestEventId);
+
+          if (index !== -1) {
+            streamEventIds.splice(index, 1);
+          }
+
+          if (streamEventIds.length === 0) {
+            this.eventIdsByStream.delete(oldestEvent.streamId);
+          }
+        }
+      }
     }
 
     return eventId;


### PR DESCRIPTION
## Summary

This change keeps a per-stream event ID list alongside the global map in InMemoryEventStore and replays only the relevant stream's future events. That avoids sorting the entire retained event set on every reconnect/resume.

## Why this matters

Before the patch, eplayEventsAfter() rebuilt and sorted all retained event IDs for the current reconnect. On busy sessions, that turns a resume path into an O(n log n) operation over the entire store even when only one stream is relevant.

The new path keeps insertion order per stream, so replay is a narrow linear walk over that stream's event IDs while still preserving FIFO eviction semantics.

## Validation

- 
px vitest run src/InMemoryEventStore.test.ts

## Checklist

- [x] Focused performance optimization
- [x] Existing tests pass
- [x] No unrelated changes