### PR TITLE
fix(stdio): report the two read failure paths instead of swallowing them

### DIFF
--- a/src/StdioClientTransport.test.ts
+++ b/src/StdioClientTransport.test.ts
@@ -183,6 +183,61 @@ it("rejects a pending send when the child reports it has exited", async () => {
   process.kill(pid, "SIGKILL");
 }, 10_000);
 
+it("closes the connection when a message is over the read buffer cap", async () => {
+  // Regression test: `ReadBuffer.append` throws once a message exceeds its cap.
+  // Thrown straight out of the transform's "data" listener, that throw
+  // destroyed the transform the child's stdout is piped into, so every later
+  // message was dropped and onclose never fired - the connection went
+  // permanently deaf instead of failing, and in-flight requests could only end
+  // in a timeout.
+  const oversized = 11 * 1024 * 1024;
+  const transport = await startTransport([
+    "-e",
+    `process.stdout.write('{"jsonrpc":"2.0","id":1,"result":{"pad":"' + 'X'.repeat(${oversized}) + '"}}\\n');` +
+      `setInterval(() => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: 2, result: {} }) + "\\n"), 100);`,
+  ]);
+
+  const errors: string[] = [];
+  const closed = new Promise<"closed">((resolve) => {
+    transport.onclose = () => resolve("closed");
+  });
+  transport.onerror = (error) => errors.push(error.message);
+
+  await expect(
+    Promise.race([closed, delay(5_000).then(() => "still open" as const)]),
+  ).resolves.toBe("closed");
+  expect(errors[0]).toMatch(/ReadBuffer exceeded maximum size/);
+
+  await transport.close();
+}, 15_000);
+
+it("reports an error on the child's stdout instead of crashing the process", async () => {
+  // Regression test: `pipe()` does not forward a source error to its
+  // destination, so the handler on the transform never saw one and the child's
+  // read end had no "error" listener at all. An error there - "read
+  // ECONNRESET" when a child dies abruptly - was an "error" event with no
+  // listener, which EventEmitter rethrows and which therefore took the whole
+  // proxy process down.
+  const transport = await startTransport(DEAF_CHILD);
+
+  const stdout = childOf(transport).stdout!;
+  const readError = Object.assign(new Error("read ECONNRESET"), {
+    code: "ECONNRESET",
+  });
+
+  expect(stdout.listenerCount("error")).toBe(1);
+
+  const reported = new Promise<Error>((resolve) => {
+    transport.onerror = resolve;
+  });
+
+  stdout.emit("error", readError);
+
+  await expect(reported).resolves.toBe(readError);
+
+  await transport.close();
+}, 10_000);
+
 it("resolves send() and leaves no listeners behind once a buffered write drains", async () => {
   // The happy path for the same code: a child that does read stdin lets the
   // buffered write flush, so "drain" arrives and the promise resolves - and

--- a/src/StdioClientTransport.ts
+++ b/src/StdioClientTransport.ts
@@ -241,24 +241,41 @@ export class StdioClientTransport implements Transport {
 
       this._process.stdout?.pipe(jsonFilterTransform);
 
-      jsonFilterTransform.on("data", (chunk) => {
-        this.onEvent?.({
-          chunk: chunk.toString(),
-          type: "data",
-        });
-
-        this._readBuffer.append(chunk);
-        this.processReadBuffer();
-      });
-
-      jsonFilterTransform.on("error", (error) => {
+      const reportError = (error: Error) => {
         this.onEvent?.({
           error,
           type: "error",
         });
 
         this.onerror?.(error);
+      };
+
+      jsonFilterTransform.on("data", (chunk) => {
+        this.onEvent?.({
+          chunk: chunk.toString(),
+          type: "data",
+        });
+
+        try {
+          this._readBuffer.append(chunk);
+          this.processReadBuffer();
+        } catch (error) {
+          // `append` throws once a message exceeds the read buffer cap. Left
+          // uncaught it destroys the transform stdout is piped into, so every
+          // later message is dropped and the connection goes deaf instead of
+          // failing. Report and close, like the upstream transport does.
+          reportError(error as Error);
+          this.close().catch(() => {});
+        }
       });
+
+      jsonFilterTransform.on("error", reportError);
+
+      // `pipe()` does not forward a source error to its destination, so the
+      // listener above never sees one. Without this, an error on the child's
+      // stdout is an "error" event with no listener, which EventEmitter
+      // rethrows - taking the whole process down.
+      this._process.stdout?.on("error", reportError);
 
       if (this._stderrStream && this._process.stderr) {
         this._process.stderr.pipe(this._stderrStream);


### PR DESCRIPTION
`StdioClientTransport` is forked from the SDK's `client/stdio.ts` — the header says so, and `6c1090e` is *"fix: align StdioClientTransport with upstream"*. Two error paths of the same handler are currently lost.

### 1. The read-buffer cap throw escapes the `data` listener

`src/StdioClientTransport.ts:250` — `this._readBuffer.append(chunk)` is not wrapped. `ReadBuffer.append` throws once a message exceeds `STDIO_DEFAULT_MAX_BUFFER_SIZE` (10 MiB). Thrown out of the transform's `"data"` listener, Node routes it to `errorOrDestroy`: the transform is destroyed while stdout is still piped into it.

Child writes one 11 MiB JSON line, then a valid JSON-RPC message every 200 ms:

```
SEEN: ["onerror:ReadBuffer exceeded maximum size of 10485760 bytes"]
messages delivered AFTER the oversized line: 0
onclose fired: false
```

The connection is permanently deaf **and never closes**, so in-flight requests can only time out.

### 2. `child.stdout` has zero `error` listeners

`:242` pipes stdout into the transform, and the `error` listener is on the *transform*. `pipe()` does not forward a source error to its destination:

```
stdout error listeners: 0
node:events:486  throw er; // Unhandled 'error' event
Error: read ECONNRESET
Node.js v24.14.1        EXIT=1
```

This was not absent by design. `bdd946d` (*"feat: ignore non-JSON output"*) **moved** it:

```diff
-      this.process.stdout?.on("error", (error) => {
+      jsonFilterTransform.on("error", (error) => {
```

A mechanical rename that changed semantics. And `processReadBuffer` (`:284`) already catches the sibling error from `readMessage`, so the intent to report is documented in the same file.

### The fix

Upstream parity: hoist the reporter into `reportError`, wrap `append`/`processReadBuffer` → report + `close()`, and attach `reportError` to `this._process.stdout` too.

**There are two defensible shapes here and I'd rather you picked.** Measured: with the `try/catch` but *without* `close()`, all 10 subsequent messages are delivered — the throw destroying the transform is the only reason they were dropped. So "report and keep going" is viable. I went with upstream parity (report + close) because the file is explicitly aligned to it; say the word if you prefer the other.

### Verification

Source reverted, tests kept: **2 failed | 6 passed** (`expected 'still open' to be 'closed'`, `expected +0 to be 1`). With the fix: **8/8**. `tsc` 0, `eslint` 0. Full suite: 17 failures, and the normalized failure set is **byte-identical to pristine `dc52af2`** (16 × `spawn tsx ENOENT`, 1 × the known Windows raw-socket 413) — set difference empty both ways.

### What I did not verify

I could **not** trigger a stdout error from the OS: three hard-kill runs with a 60 MiB backed-up pipe all ended cleanly via `onclose`. The missing listener is *measured* (`listenerCount("error") === 0`, and an error there exits 1), and the upstream attaches one — but the natural trigger is asserted from upstream behaviour, not demonstrated by me. Windows / Node 24.14.1 only.

Also worth flagging: the `onclose` double-fire on `close()` is pre-existing and not introduced here.

*Prepared with AI assistance; every claim above was executed and the outputs are verbatim.*
