### PR TITLE
fix(stdio): fire close exactly once (#86)

### DIFF
--- a/src/StdioClientTransport.test.ts
+++ b/src/StdioClientTransport.test.ts
@@ -82,6 +82,43 @@ it("settles pending sends when the child exits before the write drains", async (
   await transport.close();
 }, 10_000);
 
+it("fires close exactly once when the transport is closed", async () => {
+  // Regression test (#86): close() emitted the {type:"close"} event and then
+  // aborted the child. The abort tripped both child handlers - the "error"
+  // handler on AbortError and the "close" handler - and each fired onclose (and
+  // the second also re-emitted the close event). So a plain start()/close()
+  // delivered onclose twice and {type:"close"} twice. A single guard collapses
+  // all three paths to one notification.
+  const closeEvents: number[] = [];
+  const transport = new StdioClientTransport({
+    args: ["-e", "setTimeout(() => {}, 60000)"],
+    command: "node",
+    env: process.env as Record<string, string>,
+    onEvent: (event) => {
+      if (event.type === "close") {
+        closeEvents.push(1);
+      }
+    },
+    stderr: "ignore",
+  });
+
+  let oncloseCount = 0;
+  transport.onclose = () => {
+    oncloseCount += 1;
+  };
+
+  await transport.start();
+  await transport.close();
+
+  // The child's "close"/"error" handlers land on a later tick than close()
+  // returns, so give them room to fire before counting. Without the guard this
+  // is where the second onclose and the second close event arrive.
+  await delay(200);
+
+  expect(oncloseCount).toBe(1);
+  expect(closeEvents).toHaveLength(1);
+}, 10_000);
+
 it("settles a pending send when the transport is closed", async () => {
   // The same hang on the ordinary shutdown path: close() aborts the child, so
   // a write that has not drained yet can never complete.
@@ -115,9 +152,10 @@ it("rejects a pending send with the error stdin reports", async () => {
   const closeListenersBefore = stdin.listenerCount("close");
   const pipeError = new Error("write EPIPE");
 
-  const outcome = transport
-    .send(messageOfSize(1, 1024 * 1024))
-    .then(() => "resolved", (error: Error) => error);
+  const outcome = transport.send(messageOfSize(1, 1024 * 1024)).then(
+    () => "resolved",
+    (error: Error) => error,
+  );
 
   expect(stdin.listenerCount("drain")).toBe(1);
 
@@ -137,9 +175,10 @@ it("rejects a pending send when stdin closes", async () => {
   // start() keeps an "error" listener on stdin for the transport's lifetime.
   const errorListenersBefore = stdin.listenerCount("error");
 
-  const outcome = transport
-    .send(messageOfSize(1, 1024 * 1024))
-    .then(() => "resolved", (error: Error) => error.message);
+  const outcome = transport.send(messageOfSize(1, 1024 * 1024)).then(
+    () => "resolved",
+    (error: Error) => error.message,
+  );
 
   expect(stdin.listenerCount("drain")).toBe(1);
 
@@ -163,9 +202,10 @@ it("rejects a pending send when the child reports it has exited", async () => {
   const pid = transport.pid!;
   const errorListenersBefore = stdin.listenerCount("error");
 
-  const outcome = transport
-    .send(messageOfSize(1, 1024 * 1024))
-    .then(() => "resolved", (error: Error) => error.message);
+  const outcome = transport.send(messageOfSize(1, 1024 * 1024)).then(
+    () => "resolved",
+    (error: Error) => error.message,
+  );
 
   expect(stdin.listenerCount("drain")).toBe(1);
 

--- a/src/StdioClientTransport.ts
+++ b/src/StdioClientTransport.ts
@@ -106,6 +106,7 @@ export class StdioClientTransport implements Transport {
     return this._process?.stderr ?? null;
   }
   private _abortController: AbortController = new AbortController();
+  private _closed = false;
   private _process?: ChildProcess;
   private _readBuffer: ReadBuffer = new ReadBuffer();
   private _serverParams: StdioServerParameters;
@@ -122,9 +123,7 @@ export class StdioClientTransport implements Transport {
   }
 
   async close(): Promise<void> {
-    this.onEvent?.({
-      type: "close",
-    });
+    this._emitClose();
 
     this._abortController.abort();
     this._process = undefined;
@@ -206,7 +205,7 @@ export class StdioClientTransport implements Transport {
       this._process.on("error", (error) => {
         if (error.name === "AbortError") {
           // Expected when close() is called.
-          this.onclose?.();
+          this._emitClose();
           return;
         }
 
@@ -220,12 +219,8 @@ export class StdioClientTransport implements Transport {
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       this._process.on("close", (_code) => {
-        this.onEvent?.({
-          type: "close",
-        });
-
         this._process = undefined;
-        this.onclose?.();
+        this._emitClose();
       });
 
       this._process.stdin?.on("error", (error) => {
@@ -281,6 +276,30 @@ export class StdioClientTransport implements Transport {
         this._process.stderr.pipe(this._stderrStream);
       }
     });
+  }
+
+  /**
+   * Emit the single close notification for this transport.
+   *
+   * A close can be reached from three places that all follow one `close()`
+   * call: `close()` itself, the child's `error` handler on `AbortError`, and the
+   * child's `close` handler. Left ungated, `close()` emitted the `{type:"close"}`
+   * event and aborted, and the abort then tripped both child handlers - so
+   * `onclose` and the close event each fired twice. This makes the notification
+   * fire exactly once regardless of which path arrives first.
+   */
+  private _emitClose(): void {
+    if (this._closed) {
+      return;
+    }
+
+    this._closed = true;
+
+    this.onEvent?.({
+      type: "close",
+    });
+
+    this.onclose?.();
   }
 
   private processReadBuffer() {


### PR DESCRIPTION
## Problem

Closes #86.

`close()` fires `onclose` twice and emits `{ type: "close" }` twice.

`close()` ([`src/StdioClientTransport.ts:124`](https://github.com/punkpeye/mcp-proxy/blob/main/src/StdioClientTransport.ts#L124)) emits the close event and aborts. The abort then trips *both* child handlers:

- `process.on("error")` → `AbortError` branch → `onclose?.()`
- `process.on("close")` → `onEvent({ type: "close" })` + `onclose?.()`

Measured on a plain `start()` / `close()`:

```
onclose fired: 2x   onEvent close: 2x   (expected 1 / 1)
```

## Fix

Collapse the three close paths — `close()` itself, the `AbortError` branch, and the child `close` handler — through a single `_emitClose()` guarded by a `_closed` flag. The `{ type: "close" }` event and `onclose` then fire exactly once regardless of which path arrives first.

The change is small on purpose: no path is removed, they are all routed through one guarded emit.

## Tests

Adds one regression test to `src/StdioClientTransport.test.ts`:

- **Red before:** with any single un-guarded path (e.g. the `AbortError` branch still calling `onclose?.()` directly), a plain `start()`/`close()` delivers `onclose` twice — the test asserts exactly one `onclose` and one `{ type: "close" }` event and fails.
- **Green after:** one of each.
- `src/StdioClientTransport.test.ts` 9/9; `src/JSONFilterTransform.test.ts` 4/4. `tsc`, `eslint` and `prettier --check` clean on the changed files.

**Not verified:** the spawn-based integration suites (`proxyServer`, `protocolEras`, `startHTTPServer`, `startStdioServer`) fail on this machine on a clean `origin/main` checkout too (the `tsx` children do not connect here), so they are not a signal either way for this change. Everything above is the transport unit tests, which do spawn a real `node` child and exercise the real close path.
