### PR TITLE
fix: cap JSONFilterTransform buffer so it fails instead of growing unbounded (#85)

### DIFF
--- a/src/JSONFilterTransform.test.ts
+++ b/src/JSONFilterTransform.test.ts
@@ -148,4 +148,38 @@ describe("JSONFilterTransform", () => {
     expect(outputLines[1]).toBe('{"type": "response", "id": 2}');
     expect(outputLines[2]).toBe('{"partial": "data"}');
   });
+
+  it("fails instead of buffering an unbounded line with no newline", async () => {
+    // Regression test (#85): a child that writes a lot without ever completing a
+    // line grew `this.buffer` without bound. The downstream ReadBuffer cap never
+    // fired, because it only sees data once a full line is flushed to it - so the
+    // filter sat in front of the cap and could exhaust memory instead of failing.
+    // The buffer is now bounded. The cap is twice the SDK's stdio buffer size, so
+    // a complete (even over-cap) message still reaches ReadBuffer for the
+    // authoritative rejection; this covers the other case - a line that never
+    // terminates and so never reaches ReadBuffer at all.
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    const transform = new JSONFilterTransform();
+
+    // 21 MiB in one chunk with no newline: over the 20 MiB cap (2x the SDK's
+    // 10 MiB stdio buffer), and never flushed downstream because there is no line
+    // terminator.
+    const oversized = "x".repeat(21 * 1024 * 1024);
+    const readable = Readable.from([oversized]);
+
+    const writable = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    await expect(pipeline(readable, transform, writable)).rejects.toThrow(
+      /buffer exceeded maximum size/,
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
 });

--- a/src/JSONFilterTransform.ts
+++ b/src/JSONFilterTransform.ts
@@ -1,4 +1,21 @@
+import { STDIO_DEFAULT_MAX_BUFFER_SIZE } from "@modelcontextprotocol/client";
 import { Transform } from "node:stream";
+
+/**
+ * Largest incomplete line the filter will buffer before failing. A child that
+ * writes a lot without ever completing a line would otherwise grow `this.buffer`
+ * without bound: the downstream `ReadBuffer` cap never fires, because it only
+ * sees data once a full line is flushed to it, so the filter sat in front of the
+ * cap and could exhaust memory instead of failing.
+ *
+ * Set to twice the SDK's stdio buffer cap rather than equal to it. The filter
+ * holds at most one line still being assembled, and a legitimate message is
+ * bounded by that downstream cap - so a full-size (or even over-cap) message
+ * must still reach `ReadBuffer`, which is the authority on message size and
+ * rejects it there. The headroom lets that happen; anything past it is a line
+ * that will never terminate, which is what this bound exists to stop.
+ */
+const MAX_BUFFER_SIZE = 2 * STDIO_DEFAULT_MAX_BUFFER_SIZE;
 
 /**
  * Extracts JSON-RPC messages from a stream that may contain non-JSON output.
@@ -35,6 +52,20 @@ export class JSONFilterTransform extends Transform {
 
     // Keep the last incomplete line in the buffer
     this.buffer = lines.pop() || "";
+
+    // A single line that never terminates would grow the buffer without bound,
+    // ahead of and invisible to the downstream ReadBuffer cap. Fail here instead
+    // of letting memory run out, matching how ReadBuffer reports its own limit.
+    if (this.buffer.length > MAX_BUFFER_SIZE) {
+      this.buffer = "";
+      callback(
+        new Error(
+          `JSONFilterTransform buffer exceeded maximum size of ${MAX_BUFFER_SIZE} bytes`,
+        ),
+        null,
+      );
+      return;
+    }
 
     const jsonLines = [];
     const nonJsonLines = [];


### PR DESCRIPTION
## Problem

Closes #85.

`JSONFilterTransform` accumulates stdout into a string and only drains it at a newline ([`src/JSONFilterTransform.ts:33-37`](https://github.com/punkpeye/mcp-proxy/blob/main/src/JSONFilterTransform.ts#L33-L37)):

```ts
this.buffer += chunk.toString();
const lines = this.buffer.split("\n");
this.buffer = lines.pop() || "";
```

Nothing caps that. A child that writes a lot without ever completing a line grows the buffer without bound, and the 10 MiB `ReadBuffer` cap downstream never fires — it only sees data once a full line is flushed to it. So the filter sits in front of the cap and can exhaust memory instead of failing.

The issue's reproduction (child writes 64 MiB with no newline) measured heap growth of ~242 MiB with no error and no close — ~4x the bytes written (UTF-16 + concat intermediates). #84 made the `ReadBuffer` cap behave correctly, but the cap sits *behind* this uncapped buffer.

## Fix

Bound `this.buffer` in `_transform` and fail via the callback when it is exceeded, the same way `ReadBuffer` reports its own limit.

The cap is **twice** the SDK's stdio buffer size (`STDIO_DEFAULT_MAX_BUFFER_SIZE`), not equal to it. The filter holds at most one line still being assembled, and a legitimate message is bounded by that downstream cap — so a full-size, or even over-cap, *complete* message must still reach `ReadBuffer`, which is the authority on message size and rejects it there. The headroom lets that happen; anything past it is a line that will never terminate, which is what this bound exists to stop.

## Tests

Adds one regression test to `src/JSONFilterTransform.test.ts`:

- **Red before:** 21 MiB in one chunk with no newline buffers without bound and the pipeline never rejects — the test asserts it rejects with a buffer-exceeded error and fails.
- **Green after:** the transform errors at the cap.
- The existing `StdioClientTransport` "over the read buffer cap" test is unaffected: its 11 MiB *complete* message is under the 20 MiB filter cap, so it still flows through to `ReadBuffer` for the `ReadBuffer exceeded maximum size` rejection.
- `src/JSONFilterTransform.test.ts` 4/4; `src/StdioClientTransport.test.ts` 9/9. `tsc`, `eslint`, `prettier --check` clean on the changed files.

**Not verified:** the spawn-based integration suites (`proxyServer`, `protocolEras`, `startHTTPServer`, `startStdioServer`) fail on this machine on a clean `origin/main` checkout too (the `tsx` children do not connect here), so they are not a signal for this change either way. The reproduction and the assertions above are the transform's own unit tests.
