### PR TITLE
fix(stdio): decode child stdout through a StringDecoder so split multibyte UTF-8 survives

### DIFF
--- a/src/JSONFilterTransform.test.ts
+++ b/src/JSONFilterTransform.test.ts
@@ -148,4 +148,40 @@ describe("JSONFilterTransform", () => {
     expect(outputLines[1]).toBe('{"type": "response", "id": 2}');
     expect(outputLines[2]).toBe('{"partial": "data"}');
   });
+  it("preserves multibyte UTF-8 characters split across chunk boundaries", async () => {
+    // Regression: _transform decoded each chunk with chunk.toString(), so a
+    // multibyte UTF-8 character whose bytes landed in two different stdout
+    // chunks was decoded as two invalid halves and replaced with U+FFFD -
+    // silently corrupting any non-ASCII text (emoji, accented Latin, CJK) in a
+    // proxied JSON-RPC message. A StringDecoder holds the partial sequence.
+    const message = JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      result: { text: "launch \u{1F680} Configuraci\u00F3n a\u00F1adi\u00F3" },
+    });
+    const full = Buffer.from(message + "\n", "utf8");
+
+    // One byte per chunk is the worst case, and a real one: a slow writer or a
+    // pipe under backpressure delivers stdout a few bytes at a time.
+    const byteChunks: Buffer[] = [];
+    for (let i = 0; i < full.length; i++) {
+      byteChunks.push(full.subarray(i, i + 1));
+    }
+
+    const readable = Readable.from(byteChunks);
+    const transform = new JSONFilterTransform();
+    const outputChunks: Buffer[] = [];
+    const writable = new Writable({
+      write(chunk, _encoding, callback) {
+        outputChunks.push(chunk);
+        callback();
+      },
+    });
+
+    await pipeline(readable, transform, writable);
+
+    const output = Buffer.concat(outputChunks).toString("utf8").trim();
+    expect(output).not.toContain("\uFFFD");
+    expect(output).toBe(message);
+  });
 });

--- a/src/JSONFilterTransform.ts
+++ b/src/JSONFilterTransform.ts
@@ -1,4 +1,5 @@
 import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 
 /**
  * Extracts JSON-RPC messages from a stream that may contain non-JSON output.
@@ -10,12 +11,19 @@ import { Transform } from "node:stream";
  */
 export class JSONFilterTransform extends Transform {
   private buffer = "";
+  // Decode bytes to text through a StringDecoder rather than chunk.toString():
+  // a stdout pipe can split a multibyte UTF-8 character across two chunks, and
+  // decoding each chunk on its own turns the split bytes into U+FFFD. The
+  // decoder holds the incomplete sequence until its remaining bytes arrive.
+  private decoder = new StringDecoder("utf8");
 
   constructor() {
     super({ objectMode: false });
   }
 
   _flush(callback: (error: Error | null, chunk: Buffer | null) => void) {
+    // Flush any bytes the decoder is still holding for an incomplete character.
+    this.buffer += this.decoder.end();
     // Handle any remaining data in buffer
     const json = extractJson(this.buffer);
     if (json !== null) {
@@ -30,7 +38,7 @@ export class JSONFilterTransform extends Transform {
     _encoding: string,
     callback: (error: Error | null, chunk: Buffer | null) => void,
   ) {
-    this.buffer += chunk.toString();
+    this.buffer += this.decoder.write(chunk);
     const lines = this.buffer.split("\n");
 
     // Keep the last incomplete line in the buffer


### PR DESCRIPTION
## What

`JSONFilterTransform._transform` decoded each stdout chunk with `chunk.toString()`. When a child process writes a multibyte UTF-8 character (emoji, accented Latin, CJK) and its bytes land in **two different stdout chunks** — which happens routinely with a slow writer or under pipe backpressure, where stdout is delivered a few bytes at a time — decoding each chunk in isolation turns the split byte sequence into `U+FFFD` (the replacement character). The non-ASCII text in the proxied JSON-RPC message is silently corrupted.

## Fix

Decode through a persistent `StringDecoder("utf8")` instead of `chunk.toString()`. The decoder holds an incomplete byte sequence until the rest of its bytes arrive in a later chunk, so a character split across a boundary is reassembled correctly. `_flush` calls `decoder.end()` to emit anything still buffered.

This mirrors the upstream MCP SDK's `ReadBuffer`, which already decodes correctly — the corruption was introduced only by this filter sitting in front of it.

```diff
+import { StringDecoder } from "node:string_decoder";
 ...
+  private decoder = new StringDecoder("utf8");
 ...
   _flush(callback) {
+    this.buffer += this.decoder.end();
 ...
-    this.buffer += chunk.toString();
+    this.buffer += this.decoder.write(chunk);
```

## Test

Adds a regression test that feeds the transform **one byte per chunk** (the worst case, and a realistic one under backpressure) with a message containing an emoji and accented Latin, then asserts the output contains no `U+FFFD` and round-trips byte-for-byte.

Verified the test **fails on the current code** (the assertion `not.toContain("\uFFFD")` trips) and **passes with the fix**, so it's a genuine regression test, not a tautology.

`vitest run src/JSONFilterTransform.test.ts` → 4 passed. `tsc --noEmit` and `eslint` clean.

## Scope

One file changed plus its test. Orthogonal to the open buffer-cap PR (#88, unbounded growth) and the close-events PR (#87) — neither touches decoding.
