### PR TITLE
fix(http): drop Access-Control-Allow-Credentials when the origin is a wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,13 @@ CORS is enabled by default with:
 - **Credentials**: `true`
 - **Exposed Headers**: `Mcp-Session-Id`
 
+`Access-Control-Allow-Credentials` is omitted whenever the allowed origin comes
+out as `*`, because the Fetch Standard makes a browser
+[reject the whole CORS response](https://fetch.spec.whatwg.org/#http-access-control-allow-credentials)
+when it sees both. Credentialed browser requests (`credentials: "include"`,
+`withCredentials`) therefore need an explicit `origin` — a list or a function,
+not a wildcard.
+
 `Mcp-Method` and `Mcp-Name` are required on 2026-07-28 streamable HTTP POSTs, so
 browser clients on that revision need them allowed. That revision's
 `Mcp-Param-*` headers are a prefix, which `Access-Control-Allow-Headers` cannot

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -2354,22 +2354,18 @@ it("uses default CORS settings when cors: true", async () => {
   });
 
   expect(response.status).toBe(204);
-  // The default pairs `credentials: true` with a wildcard origin, which the
-  // Fetch Standard forbids for credentialed requests - so the wildcard is
-  // reflected as the actual request origin instead of the literal "*". See
-  // the dedicated test below for the invariant this maintains.
-  expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
-    "https://example.com",
-  );
+  expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
   expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
     "Content-Type, Authorization, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id, Mcp-Method, Mcp-Name",
   );
-  expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  // The default `credentials: true` is deliberately not emitted alongside the
+  // wildcard - see the dedicated test below.
+  expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
 
   await httpServer.close();
 });
 
-it("never combines wildcard origin with credentials: true (Fetch Standard forbids it)", async () => {
+it("never combines wildcard origin with credentials (Fetch Standard forbids it)", async () => {
   const port = await getRandomPort();
 
   const httpServer = await startHTTPServer({
@@ -2394,18 +2390,58 @@ it("never combines wildcard origin with credentials: true (Fetch Standard forbid
 
   expect(response.status).toBe(204);
 
-  const allowOrigin = response.headers.get("Access-Control-Allow-Origin");
-  const allowCredentials = response.headers.get(
-    "Access-Control-Allow-Credentials",
-  );
-
   // https://fetch.spec.whatwg.org/#http-access-control-allow-credentials -
   // a browser rejects the whole CORS response if these two ever appear
-  // together, silently failing any credentialed request.
-  if (allowCredentials === "true") {
-    expect(allowOrigin).not.toBe("*");
-    expect(allowOrigin).toBe("https://example.com");
-  }
+  // together, silently failing every credentialed request. The wildcard stays
+  // and the credentials header drops, rather than the reverse: reflecting the
+  // request origin back would hand any origin a working credentialed grant.
+  expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  expect(response.headers.get("Vary")).toBe("Origin");
+
+  await httpServer.close();
+});
+
+it("still sends credentials when an explicit origin allow-list matches", async () => {
+  const port = await getRandomPort();
+
+  const httpServer = await startHTTPServer({
+    cors: { credentials: true, origin: ["https://app.example"] },
+    createServer: async () => {
+      const mcpServer = new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+      return mcpServer;
+    },
+    port,
+  });
+
+  const allowed = await fetch(`http://localhost:${port}/mcp`, {
+    headers: {
+      "Access-Control-Request-Method": "POST",
+      Origin: "https://app.example",
+    },
+    method: "OPTIONS",
+  });
+
+  expect(allowed.headers.get("Access-Control-Allow-Origin")).toBe(
+    "https://app.example",
+  );
+  expect(allowed.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+
+  // A rejected origin still varies by `Origin`, so a shared cache cannot serve
+  // this answer to the allowed one.
+  const rejected = await fetch(`http://localhost:${port}/mcp`, {
+    headers: {
+      "Access-Control-Request-Method": "POST",
+      Origin: "https://evil.example",
+    },
+    method: "OPTIONS",
+  });
+
+  expect(rejected.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  expect(rejected.headers.get("Vary")).toBe("Origin");
 
   await httpServer.close();
 });

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -2354,11 +2354,58 @@ it("uses default CORS settings when cors: true", async () => {
   });
 
   expect(response.status).toBe(204);
-  expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  // The default pairs `credentials: true` with a wildcard origin, which the
+  // Fetch Standard forbids for credentialed requests - so the wildcard is
+  // reflected as the actual request origin instead of the literal "*". See
+  // the dedicated test below for the invariant this maintains.
+  expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+    "https://example.com",
+  );
   expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
     "Content-Type, Authorization, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id, Mcp-Method, Mcp-Name",
   );
   expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+
+  await httpServer.close();
+});
+
+it("never combines wildcard origin with credentials: true (Fetch Standard forbids it)", async () => {
+  const port = await getRandomPort();
+
+  const httpServer = await startHTTPServer({
+    // No `cors` option passed at all - the actual default path, not `cors: true`.
+    createServer: async () => {
+      const mcpServer = new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+      return mcpServer;
+    },
+    port,
+  });
+
+  const response = await fetch(`http://localhost:${port}/mcp`, {
+    headers: {
+      "Access-Control-Request-Method": "POST",
+      Origin: "https://example.com",
+    },
+    method: "OPTIONS",
+  });
+
+  expect(response.status).toBe(204);
+
+  const allowOrigin = response.headers.get("Access-Control-Allow-Origin");
+  const allowCredentials = response.headers.get(
+    "Access-Control-Allow-Credentials",
+  );
+
+  // https://fetch.spec.whatwg.org/#http-access-control-allow-credentials -
+  // a browser rejects the whole CORS response if these two ever appear
+  // together, silently failing any credentialed request.
+  if (allowCredentials === "true") {
+    expect(allowOrigin).not.toBe("*");
+    expect(allowOrigin).toBe("https://example.com");
+  }
 
   await httpServer.close();
 });

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -615,8 +615,21 @@ const applyCorsHeaders = (
       }
     }
 
+    // A wildcard `Access-Control-Allow-Origin` combined with
+    // `Access-Control-Allow-Credentials: true` is forbidden by the Fetch
+    // Standard (https://fetch.spec.whatwg.org/#http-access-control-allow-credentials)
+    // - a browser rejects the whole CORS response for any credentialed
+    // request, silently, before it ever reaches the MCP handler. Reflecting
+    // the actual request `Origin` instead of the literal `"*"` is the
+    // standard workaround (see the `cors` npm package), and is safe here
+    // because it only changes the value emitted, not which origins pass.
+    if (allowedOrigin === "*" && finalCorsOptions.credentials === true) {
+      allowedOrigin = origin.origin;
+    }
+
     if (allowedOrigin !== "false") {
       res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+      res.setHeader("Vary", "Origin");
     }
 
     // Handle credentials

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -615,25 +615,26 @@ const applyCorsHeaders = (
       }
     }
 
-    // A wildcard `Access-Control-Allow-Origin` combined with
-    // `Access-Control-Allow-Credentials: true` is forbidden by the Fetch
-    // Standard (https://fetch.spec.whatwg.org/#http-access-control-allow-credentials)
-    // - a browser rejects the whole CORS response for any credentialed
-    // request, silently, before it ever reaches the MCP handler. Reflecting
-    // the actual request `Origin` instead of the literal `"*"` is the
-    // standard workaround (see the `cors` npm package), and is safe here
-    // because it only changes the value emitted, not which origins pass.
-    if (allowedOrigin === "*" && finalCorsOptions.credentials === true) {
-      allowedOrigin = origin.origin;
-    }
+    // An array or function origin resolves per request, so the response is
+    // origin-dependent whether or not this one was allowed - a shared cache
+    // that missed that would hand one origin's answer to another.
+    res.setHeader("Vary", "Origin");
 
     if (allowedOrigin !== "false") {
       res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
-      res.setHeader("Vary", "Origin");
     }
 
     // Handle credentials
-    if (finalCorsOptions.credentials !== undefined) {
+    // The Fetch Standard forbids pairing `Access-Control-Allow-Credentials`
+    // with a wildcard origin
+    // (https://fetch.spec.whatwg.org/#http-access-control-allow-credentials):
+    // a browser rejects the entire CORS response when it sees both, so the
+    // header grants nothing and only breaks callers that would otherwise be
+    // fine. Reflecting the request origin instead would "fix" it by handing
+    // every origin a working credentialed grant, which is not something a
+    // wildcard default should imply - configure an explicit `origin` to use
+    // credentials.
+    if (finalCorsOptions.credentials !== undefined && allowedOrigin !== "*") {
       res.setHeader(
         "Access-Control-Allow-Credentials",
         finalCorsOptions.credentials.toString(),


### PR DESCRIPTION
## What's wrong

The default CORS config pairs `Access-Control-Allow-Origin: *` with
`Access-Control-Allow-Credentials: true`. That combination is forbidden by the
[Fetch Standard](https://fetch.spec.whatwg.org/#http-access-control-allow-credentials):
a browser rejects the entire CORS response for any credentialed request, silently,
before it reaches the MCP handler.

Original diagnosis and repro by @pacocartones.

## The fix

Drop `Access-Control-Allow-Credentials` when the resolved origin is `*`.

```
default          -> Access-Control-Allow-Origin: *                     (no credentials header)
origin allow-list -> Access-Control-Allow-Origin: https://app.example   Access-Control-Allow-Credentials: true
```

No browser-visible behaviour changes: non-credentialed cross-origin requests
already worked via `*` and still do, credentialed requests already failed and
still do. The response just stops carrying a header that grants nothing.

Credentialed browser clients opt in with an explicit `origin` list or function,
which already works.

### Why not reflect the request origin

The first revision of this PR reflected the request `Origin` instead of the
literal `*`. That makes credentialed requests *work for every origin* — turning
a fail-closed default into a fail-open one, on a proxy that does no `Origin` or
`Host` validation and is usually run on localhost. `cors@2.8.5` does not do this
either: `configureOrigin` emits a literal `*` for `origin: '*'` and reflects only
for the array/function/`true` forms.

`Vary: Origin` is now emitted for rejected origins too, so a shared cache cannot
serve one origin's answer to another.

## Tests

- default CORS: asserts `*` with no credentials header
- explicit allow-list: asserts credentials still sent, and `Vary: Origin` on rejection

`vitest run` 183/183, `tsc` and `eslint` clean.
