### PR TITLE
fix(http): declare UTF-8 charset for JSON and SSE responses

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -168,6 +168,9 @@ it(
     });
 
     expect(initializeResponse.status).toBe(200);
+    expect(initializeResponse.headers.get("content-type")).toBe(
+      "text/event-stream; charset=utf-8",
+    );
     const sessionId = initializeResponse.headers.get("mcp-session-id");
     expect(sessionId).toBeTruthy();
     await initializeResponse.text();
@@ -198,6 +201,30 @@ it(
   },
   15_000,
 );
+
+it("declares UTF-8 on JSON error responses", async () => {
+  const port = await getRandomPort();
+  const httpServer = await startHTTPServer({
+    apiKey: "test-api-key",
+    createServer: async () =>
+      new Server(
+        { name: "test", version: "1.0.0" },
+        { capabilities: {} },
+      ),
+    port,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`);
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+  } finally {
+    await httpServer.close();
+  }
+});
 
 it("proxies messages between SSE and stdio servers", async () => {
   const stdioTransport = new StdioClientTransport({

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -226,6 +226,86 @@ it("declares UTF-8 on JSON error responses", async () => {
   }
 });
 
+it("declares UTF-8 on JSON-mode responses written by the SDK transport", async () => {
+  // `enableJsonResponse` answers with a plain JSON body instead of an SSE
+  // frame, and that body is written by the SDK transport rather than by this
+  // module. It is the path a Latin-1-defaulting client renders as mojibake, so
+  // it only stays covered as long as the normalisation sits at the writeHead
+  // boundary.
+  const port = await getRandomPort();
+  const httpServer = await startHTTPServer({
+    createServer: async () =>
+      new Server({ name: "test", version: "1.0.0" }, { capabilities: {} }),
+    enableJsonResponse: true,
+    port,
+    stateless: true,
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+          protocolVersion: "2025-03-26",
+        },
+      }),
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    await response.text();
+  } finally {
+    await httpServer.close();
+  }
+});
+
+it("leaves content types other than JSON and SSE alone", async () => {
+  // The charset is only appended for the two media types MCP speaks. A
+  // lookalike must not match on prefix, and a charset the caller chose
+  // deliberately must never be rewritten.
+  const port = await getRandomPort();
+  const httpServer = await startHTTPServer({
+    createServer: async () =>
+      new Server({ name: "test", version: "1.0.0" }, { capabilities: {} }),
+    onUnhandledRequest: async (req, res) => {
+      res.writeHead(200, {
+        "Content-Type": req.headers["x-echo-content-type"] as string,
+      });
+      res.end("body");
+    },
+    port,
+  });
+
+  try {
+    for (const contentType of [
+      "text/plain",
+      "application/json-seq",
+      "application/problem+json",
+      "application/json; charset=iso-8859-1",
+    ]) {
+      const response = await fetch(`http://localhost:${port}/other`, {
+        headers: { "x-echo-content-type": contentType },
+      });
+
+      expect(response.headers.get("content-type")).toBe(contentType);
+      await response.text();
+    }
+  } finally {
+    await httpServer.close();
+  }
+});
+
 it("proxies messages between SSE and stdio servers", async () => {
   const stdioTransport = new StdioClientTransport({
     args: ["src/fixtures/simple-stdio-server.ts"],

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -31,6 +31,89 @@ import { InMemoryEventStore } from "./InMemoryEventStore.js";
 const DEFAULT_KEEP_ALIVE_TIMEOUT = 300_000;
 
 /**
+ * Adds an explicit UTF-8 charset to text-based MCP response media types.
+ *
+ * JSON and SSE default to UTF-8 in their respective specifications, but some
+ * HTTP clients (notably Python's urllib) decode an unqualified response as
+ * Latin-1. Normalising at the Node response boundary also covers responses
+ * produced by the MCP SDK transports, not only the error responses built in
+ * this module.
+ */
+const addUtf8Charset = (contentType: string): string => {
+  if (
+    /;\s*charset=/i.test(contentType) ||
+    !/^(application\/json|text\/event-stream)(?:\s*;|$)/i.test(contentType)
+  ) {
+    return contentType;
+  }
+
+  return `${contentType}; charset=utf-8`;
+};
+
+const normalizeResponseHeaders = (
+  headers: http.OutgoingHttpHeader[] | http.OutgoingHttpHeaders,
+): http.OutgoingHttpHeader[] | http.OutgoingHttpHeaders => {
+  if (Array.isArray(headers)) {
+    return headers.map((value, index) => {
+      const headerName = headers[index - 1];
+      if (
+        index % 2 === 1 &&
+        typeof headerName === "string" &&
+        headerName.toLowerCase() === "content-type" &&
+        typeof value === "string"
+      ) {
+        return addUtf8Charset(value);
+      }
+
+      return value;
+    });
+  }
+
+  const normalizedHeaders = { ...headers };
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === "content-type" && typeof value === "string") {
+      normalizedHeaders[name] = addUtf8Charset(value);
+    }
+  }
+
+  return normalizedHeaders;
+};
+
+/**
+ * Normalise Content-Type immediately before Node sends the headers. This is
+ * deliberately installed per response: the MCP SDK can call writeHead itself,
+ * bypassing the response construction paths in this package.
+ */
+const ensureUtf8ResponseCharset = (res: http.ServerResponse): void => {
+  const originalWriteHead = res.writeHead.bind(res) as (
+    statusCode: number,
+    statusMessage?: http.OutgoingHttpHeader[] | http.OutgoingHttpHeaders | string,
+    headers?: http.OutgoingHttpHeader[] | http.OutgoingHttpHeaders,
+  ) => http.ServerResponse;
+
+  res.writeHead = ((statusCode, statusMessageOrHeaders, headers) => {
+    const currentContentType = res.getHeader("Content-Type");
+    if (typeof currentContentType === "string") {
+      res.setHeader("Content-Type", addUtf8Charset(currentContentType));
+    }
+
+    const responseHeaders =
+      typeof statusMessageOrHeaders === "string" ? headers : statusMessageOrHeaders;
+    if (responseHeaders) {
+      const normalizedHeaders = normalizeResponseHeaders(responseHeaders);
+
+      if (typeof statusMessageOrHeaders === "string") {
+        return originalWriteHead(statusCode, statusMessageOrHeaders, normalizedHeaders);
+      }
+
+      return originalWriteHead(statusCode, normalizedHeaders);
+    }
+
+    return originalWriteHead(statusCode, statusMessageOrHeaders, headers);
+  }) as http.ServerResponse["writeHead"];
+};
+
+/**
  * How long a 2025-era stream session with nothing attached to it is kept before
  * the reaper closes it.
  *
@@ -1762,6 +1845,8 @@ export const startHTTPServer = async <T extends ServerLike>({
    * @author https://dev.classmethod.jp/articles/mcp-sse/
    */
   const requestListener: http.RequestListener = async (req, res) => {
+    ensureUtf8ResponseCharset(res);
+
     // Apply CORS headers
     applyCorsHeaders(req, res, cors);
 


### PR DESCRIPTION
## Summary

- add an explicit `charset=utf-8` to JSON and SSE response Content-Type headers
- normalize headers at the Node response boundary so responses produced by MCP SDK transports are covered
- add integration coverage for SSE initialization and JSON authentication errors

## Why this matters

The response bytes are already UTF-8, but the charset is omitted. Some clients (notably Python clients using `urllib`) fall back to Latin-1 and display Cyrillic/CJK as mojibake. This can cause an agent to misread a note or tool result, make an incorrect decision, and potentially write corrupted text back to the vault. It does not corrupt CouchDB data by itself, and clients such as Obsidian LiveSync that talk directly to CouchDB are not affected.

## Validation

Targeted `startHTTPServer` integration tests pass, as do TypeScript and ESLint checks. The full suite is affected in this environment by an unrelated Node/tsx `uv_os_get_passwd ENOMEM` failure in fixture processes.