### PR TITLE
fix(http): pause the request stream when the body overflows the cap

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -10,11 +10,12 @@ import { getRandomPort } from "get-port-please";
 import http from "http";
 import https from "https";
 import net from "net";
+import { PassThrough } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
 import { expect, it, vi } from "vitest";
 
 import { proxyServer } from "./proxyServer.js";
-import { startHTTPServer } from "./startHTTPServer.js";
+import { getBody, startHTTPServer } from "./startHTTPServer.js";
 
 if (!("EventSource" in global)) {
   // @ts-expect-error - figure out how to use --experimental-eventsource with vitest
@@ -3686,3 +3687,48 @@ it("finishes reaping a session whose onClose rejects", async () => {
     process.off("unhandledRejection", onUnhandledRejection);
   }
 }, 15_000);
+
+it("pauses the request stream when a chunked body overflows the cap, instead of ingesting more", async () => {
+  // Regression test for the getBody() streaming overflow branch. When the
+  // running byte count crossed maxBodySize the promise resolved with
+  // { tooLarge: true } but the stream was left in flowing mode. It kept
+  // emitting "data" after the caller had already decided to answer 413,
+  // buffering an unbounded oversize body and racing sendPayloadTooLarge()'s
+  // teardown. Pausing the stream in that branch applies TCP backpressure and
+  // stops further ingestion.
+  //
+  // A PassThrough stands in for the http.IncomingMessage: getBody only uses
+  // the readable side and request.headers, and a raw socket cannot make the
+  // "keeps flowing after resolve" race observable as deterministically.
+  const maxBodySize = 256;
+
+  const request = new PassThrough() as unknown as http.IncomingMessage;
+  (request as unknown as { headers: http.IncomingHttpHeaders }).headers = {};
+
+  const resultPromise = getBody(request, maxBodySize);
+
+  // First writes already exceed the cap, split across chunks so only the
+  // streaming counter (not a declared Content-Length) can catch it.
+  (request as unknown as PassThrough).write(Buffer.alloc(200, "a"));
+  (request as unknown as PassThrough).write(Buffer.alloc(200, "b"));
+
+  const result = await resultPromise;
+
+  expect(result).toEqual({ limit: maxBodySize, tooLarge: true });
+
+  // The overflow branch must have paused the stream so the socket backs off.
+  expect((request as unknown as PassThrough).isPaused()).toBe(true);
+
+  // Prove no more bytes are ingested after the decision: a probe attached now
+  // must stay silent. Without the pause the stream is still flowing and this
+  // listener fires on the next write, which is the exact race being fixed.
+  let dataAfterResolve = 0;
+  (request as unknown as PassThrough).on("data", () => {
+    dataAfterResolve += 1;
+  });
+  (request as unknown as PassThrough).write(Buffer.alloc(200, "c"));
+
+  await delay(30);
+
+  expect(dataAfterResolve).toBe(0);
+});

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -150,7 +150,7 @@ type BodyResult =
   | { readonly body: unknown; readonly tooLarge?: never }
   | { readonly limit: number; readonly tooLarge: true };
 
-const getBody = (
+export const getBody = (
   request: http.IncomingMessage,
   maxBodySize: MaxBodySizeOption = DEFAULT_MAX_BODY_SIZE,
 ) => {
@@ -176,6 +176,12 @@ const getBody = (
         if (maxBodySize !== false) {
           size += chunk.length;
           if (size > maxBodySize) {
+            // Stop reading immediately so the socket applies TCP backpressure
+            // instead of this process buffering an unbounded oversize body.
+            // Without this the stream stays in flowing mode and keeps
+            // emitting "data" after the promise settles, racing the 413
+            // teardown in sendPayloadTooLarge.
+            request.pause();
             resolve({ limit: maxBodySize, tooLarge: true });
             return;
           }


### PR DESCRIPTION
## Problem

`getBody()` in `src/startHTTPServer.ts` guards the request body size while streaming:

```ts
.on("data", (chunk) => {
  if (maxBodySize !== false) {
    size += chunk.length;
    if (size > maxBodySize) {
      resolve({ limit: maxBodySize, tooLarge: true });
      return; // <-- stream left in flowing mode
    }
  }
  bodyParts.push(chunk);
})
```

Once the running byte count crosses `maxBodySize` the promise resolves with `{ tooLarge: true }`, but the request stream is **not** paused or destroyed. It stays in flowing mode and keeps emitting `"data"`, so:

- an oversize body continues to be ingested into this process with no bound, growing buffers instead of applying TCP backpressure, and
- every extra chunk that arrives after the decision races the 413 teardown performed later by `sendPayloadTooLarge()`.

`sendPayloadTooLarge()` does call `req.pause()`, but only *after* `getBody` resolves and control returns to the request handler. Between the `resolve()` and that call, the socket keeps feeding data.

## Fix

Pause the stream in the overflow branch, before resolving, so the socket backs off immediately and no further bytes are read:

```ts
if (size > maxBodySize) {
  request.pause();
  resolve({ limit: maxBodySize, tooLarge: true });
  return;
}
```

## Test

`getBody` is exported so the race is observable directly rather than through an integration path that already pauses later. The added test in `src/startHTTPServer.test.ts` drives an oversize chunked body (256 B cap, 200 B chunks) and asserts:

- the promise resolves with `{ limit, tooLarge: true }`,
- `request.isPaused()` is `true` after the overflow decision, and
- a `"data"` probe attached after the decision receives **zero** further chunks when more is written.

RED→GREEN verified against this branch:

```
# without the request.pause() line:
× pauses the request stream when a chunked body overflows the cap, instead of ingesting more
  AssertionError: expected false to be true   (request.isPaused())

# with the fix:
✓ pauses the request stream when a chunked body overflows the cap, instead of ingesting more
```

Full `src/startHTTPServer.test.ts` suite: **64 passed**. `tsc` and `eslint` on the changed files are clean.