### PR TITLE
fix(http): guard the standalone GET stream handleRequest against unhandled rejection

### DIFF
--- a/src/startHTTPServer.get-stream-error.test.ts
+++ b/src/startHTTPServer.get-stream-error.test.ts
@@ -1,0 +1,114 @@
+import * as nodeTransportModule from "@modelcontextprotocol/node";
+import { Server } from "@modelcontextprotocol/server";
+import { getRandomPort } from "get-port-please";
+import { setTimeout as delay } from "node:timers/promises";
+import { expect, it, vi } from "vitest";
+
+import { startHTTPServer } from "./startHTTPServer.js";
+
+// Regression: the GET branch of handleStreamRequest (the standalone SSE stream
+// used for reconnection / Last-Event-ID replay) awaited transport.handleRequest
+// without a try/catch, unlike the POST and DELETE branches. The request listener
+// handed to http.createServer is async and its promise is never awaited, so a
+// rejection from the standalone GET stream surfaced as an unhandled rejection
+// (killing the process) and left the request hanging. The catch now settles the
+// response, mirroring the POST and DELETE guards in this file.
+it("does not crash when the standalone GET stream error path runs after headers are sent", async () => {
+  const port = await getRandomPort();
+
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const original =
+    nodeTransportModule.NodeStreamableHTTPServerTransport.prototype
+      .handleRequest;
+
+  // Let the POST initialize run for real so a stateful session is registered,
+  // but make the standalone GET stream flush SSE headers and then throw - the
+  // exact shape of a mid-replay failure for a reconnecting client.
+  vi.spyOn(
+    nodeTransportModule.NodeStreamableHTTPServerTransport.prototype,
+    "handleRequest",
+  ).mockImplementation(async function (
+    this: unknown,
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+    ...rest: unknown[]
+  ) {
+    if (req.method === "GET") {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write(": open\n\n");
+      throw new Error("simulated standalone GET stream failure after headers");
+    }
+
+    return (original as (...args: unknown[]) => Promise<void>).call(
+      this,
+      req,
+      res,
+      ...rest,
+    );
+  });
+
+  const httpServer = await startHTTPServer({
+    createServer: async () =>
+      new Server({ name: "test", version: "1.0.0" }, { capabilities: {} }),
+    port,
+  });
+
+  try {
+    const initializeResponse = await fetch(`http://localhost:${port}/mcp`, {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "hs", version: "1.0.0" },
+          protocolVersion: "2025-03-26",
+        },
+      }),
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(initializeResponse.status).toBe(200);
+    const sessionId = initializeResponse.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    await initializeResponse.text();
+
+    // Reconnecting standalone GET stream that fails mid-replay.
+    const streamResponse = await fetch(`http://localhost:${port}/mcp`, {
+      headers: {
+        accept: "text/event-stream",
+        "last-event-id": "bogus-event-id",
+        "mcp-session-id": sessionId!,
+      },
+      method: "GET",
+    });
+
+    // Headers were already flushed, so the client sees a streamed 200 that ends.
+    expect(streamResponse.status).toBe(200);
+    await streamResponse.text().catch(() => undefined);
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalled();
+    });
+    await delay(100);
+
+    // The crux: the post-headers error path on the GET stream must not produce
+    // an unhandled rejection.
+    expect(unhandledRejections).toEqual([]);
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
+    consoleError.mockRestore();
+    vi.restoreAllMocks();
+    await httpServer.close();
+  }
+});

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -1444,7 +1444,23 @@ const handleStreamRequest = async <T extends ServerLike>({
 
     trackSessionStream(activeTransport, res);
 
-    await activeTransport.transport.handleRequest(req, res);
+    try {
+      await activeTransport.transport.handleRequest(req, res);
+    } catch (error) {
+      // The standalone GET stream flushes SSE headers before it starts
+      // replaying events (e.g. for a reconnecting client's Last-Event-ID), so a
+      // mid-stream failure cannot be reported with a fresh status. The request
+      // listener handed to createServer is async and never awaited, so a throw
+      // here would reject as an unhandled rejection and leave the response
+      // hanging. Settle it instead, mirroring the POST and DELETE catch guards.
+      console.error("[mcp-proxy] error handling stream request", error);
+
+      if (res.headersSent) {
+        res.end();
+      } else {
+        res.writeHead(500).end("Error handling request");
+      }
+    }
 
     return true;
   }


### PR DESCRIPTION
## What

The GET branch of `handleStreamRequest` — the standalone SSE stream used when a client reconnects (e.g. with `Last-Event-ID`) — awaited `activeTransport.transport.handleRequest(req, res)` without a try/catch. The POST and DELETE branches in the same function both guard this call; the GET branch was the only one left unprotected.

## Why it matters

The request listener handed to `http.createServer` is `async`, and its returned promise is never awaited. So when the standalone GET stream rejects mid-flight — for instance if event replay for a reconnecting client's `Last-Event-ID` throws, or a write fails after the client has gone away — the rejection surfaces as an **unhandled promise rejection** (which terminates the process under Node's default policy) and leaves the response hanging: the SSE headers have already been flushed, but `res.end()` is never called, so the client blocks until its timeout.

## The fix

Wrap the GET `handleRequest` in a try/catch that settles the response, mirroring the existing POST and DELETE guards: once the response is committed we can only `res.end()` it (status/headers are already on the wire); otherwise we send a 500. Either way the request settles instead of rejecting the listener.

## Test

Adds `src/startHTTPServer.get-stream-error.test.ts`. It registers a real stateful session via `initialize`, then makes the standalone GET stream flush SSE headers and throw. Before the fix the request hangs (the response never settles) and the listener rejects; after the fix the response ends cleanly and no unhandled rejection is produced.

`tsc` and `eslint` clean; the existing `startHTTPServer.test.ts` suite stays green (63 passing).
