### PR TITLE
fix(startHTTPServer): guard modern leg against 1.x-SDK servers (#96)

### DIFF
--- a/src/startHTTPServer.modern-era-guard.test.ts
+++ b/src/startHTTPServer.modern-era-guard.test.ts
@@ -1,0 +1,113 @@
+import { Server } from "@modelcontextprotocol/server";
+import { getRandomPort } from "get-port-please";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { startHTTPServer } from "./startHTTPServer.js";
+
+/**
+ * Regression for #96: the 2026-07-28 (modern) leg crashes when `createServer`
+ * returns a server built by the 1.x MCP SDK (e.g. fastmcp <=4.x, which pins
+ * `mcp-proxy` `^6.4.6`). Such a server never sets `_supportedProtocolVersions`,
+ * so the modern SDK handler throws `Cannot read properties of undefined
+ * (reading 'includes')` inside `installDiscoverHandler` before the session is
+ * usable. Legacy-handshake clients keep working, so this only shows up against
+ * real modern (Claude) traffic in production.
+ *
+ * A 1.x server is duck-typed here by taking a real 2.x `Server` and removing
+ * the property the modern SDK route dereferences - the narrowest faithful stand
+ * in for "the instance cannot serve the modern route".
+ */
+
+const running: Array<{ close: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  while (running.length > 0) {
+    await running.pop()?.close();
+  }
+  vi.restoreAllMocks();
+});
+
+const makeLegacyEraServer = (): Server => {
+  const server = new Server(
+    { name: "legacy-sdk-server", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  // Simulate a server built by the 1.x SDK: the property the 2026-07-28 route
+  // reads is simply absent.
+  delete (server as unknown as { _supportedProtocolVersions?: unknown })
+    ._supportedProtocolVersions;
+
+  return server;
+};
+
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
+
+// A request that mcp-proxy classifies as modern: a JSON-RPC request whose
+// params carry the required 2026-07-28 `_meta` envelope, with the matching
+// MCP-Protocol-Version header.
+const modernRequest = (port: number) =>
+  fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "tools/list",
+      params: {
+        _meta: {
+          "io.modelcontextprotocol/clientCapabilities": {},
+          "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+        },
+      },
+    }),
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+      // Required on 2026-07-28 Streamable HTTP POSTs; without it the SDK
+      // rejects on the header/body cross-check before reaching the crash.
+      "Mcp-Method": "tools/list",
+      "MCP-Protocol-Version": MODERN_PROTOCOL_VERSION,
+    },
+    method: "POST",
+  });
+
+it("does not crash the modern leg when createServer returns a 1.x-SDK server (#96)", async () => {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const port = await getRandomPort();
+  const httpServer = await startHTTPServer({
+    createServer: async () => makeLegacyEraServer(),
+    port,
+  });
+  running.push(httpServer);
+
+  const response = await modernRequest(port);
+  const text = await response.text();
+
+  // The SDK's `installDiscoverHandler` TypeError must never be reached: it would
+  // surface through the modern handler's `onerror` as a logged error.
+  const sawSdkCrash = errorSpy.mock.calls.some((call) =>
+    call.some(
+      (arg) =>
+        arg instanceof TypeError &&
+        /Cannot read properties of undefined \(reading 'includes'\)/.test(
+          arg.message,
+        ),
+    ),
+  );
+  expect(sawSdkCrash, "modern handler crashed inside the SDK").toBe(false);
+
+  // The request must be answered gracefully rather than 500ing the session.
+  expect(response.status).not.toBe(500);
+  expect(response.status).toBe(400);
+
+  // A graceful refusal is a JSON-RPC error object, not an opaque 500 body.
+  const body = JSON.parse(text) as {
+    error?: { code?: number; message?: string };
+    id?: unknown;
+    jsonrpc?: string;
+  };
+  expect(body.jsonrpc).toBe("2.0");
+  expect(body.id).toBe(1);
+  expect(body.error).toBeDefined();
+  expect(body.error?.message).toMatch(/unsupported protocol version/i);
+});

--- a/src/startHTTPServer.modern-era-guard.test.ts
+++ b/src/startHTTPServer.modern-era-guard.test.ts
@@ -1,4 +1,4 @@
-import { Server } from "@modelcontextprotocol/server";
+import { McpServer, Server } from "@modelcontextprotocol/server";
 import { getRandomPort } from "get-port-please";
 import { afterEach, expect, it, vi } from "vitest";
 
@@ -42,6 +42,24 @@ const makeLegacyEraServer = (): Server => {
 };
 
 const MODERN_PROTOCOL_VERSION = "2026-07-28";
+
+// The high-level API: `createServer` hands back an `McpServer`, whose inner
+// `.server` is what the SDK dereferences. The guard must let this through - the
+// wrapper never declares `_supportedProtocolVersions` itself.
+const makeHighLevelServer = (): McpServer => {
+  const server = new McpServer(
+    { name: "high-level-server", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.registerTool(
+    "ping",
+    { description: "ping", inputSchema: {} },
+    async () => ({ content: [{ text: "pong", type: "text" as const }] }),
+  );
+
+  return server;
+};
 
 // A request that mcp-proxy classifies as modern: a JSON-RPC request whose
 // params carry the required 2026-07-28 `_meta` envelope, with the matching
@@ -110,4 +128,25 @@ it("does not crash the modern leg when createServer returns a 1.x-SDK server (#9
   expect(body.id).toBe(1);
   expect(body.error).toBeDefined();
   expect(body.error?.message).toMatch(/unsupported protocol version/i);
+});
+
+it("still serves the modern leg when createServer returns an McpServer", async () => {
+  // The guard must key off the object `serveModern` actually dereferences. It
+  // unwraps `McpServer` to its inner `.server`, so judging the wrapper - which
+  // never declares `_supportedProtocolVersions` - would refuse every consumer
+  // on the SDK's high-level API, turning a crash fix into a total outage.
+  const port = await getRandomPort();
+  const httpServer = await startHTTPServer({
+    createServer: async () => makeHighLevelServer(),
+    port,
+  });
+  running.push(httpServer);
+
+  const response = await modernRequest(port);
+  const body = (await response.json()) as {
+    result?: { tools?: Array<{ name: string }> };
+  };
+
+  expect(response.status).toBe(200);
+  expect(body.result?.tools?.map((tool) => tool.name)).toEqual(["ping"]);
 });

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -10,6 +10,7 @@ import {
   isInitializeRequest,
   isLegacyRequest,
   McpHttpHandler,
+  McpServer,
   Server,
   ServerNotifier,
 } from "@modelcontextprotocol/server";
@@ -846,15 +847,28 @@ type ModernLeg<T> = {
  * (issue #96).
  *
  * Duck-typing the exact property the SDK reads is the narrowest predicate that
- * predicts the crash: it does not depend on SDK class identity (unreliable
- * across duplicated or hoisted copies of the SDK) and it keeps working if some
- * future non-SDK server legitimately declares the same array.
+ * predicts the crash, because it does not depend on the instance being any
+ * particular class - only on the dereference the SDK is about to perform.
+ *
+ * The one thing that must be mirrored is *which* object gets dereferenced:
+ * `serveModern` unwraps an `McpServer` to its inner `.server` first, so a
+ * high-level instance has to be judged by that inner server. The wrapper itself
+ * never declares the property, so checking it directly would refuse every
+ * consumer using the SDK's high-level API. `instanceof` is the right test here
+ * despite class identity being fragile in general: `McpServer` is imported from
+ * the same module instance that provides `createMcpHandler`, so this comparison
+ * is the very one `serveModern` makes - when it does not unwrap (a duplicated
+ * SDK copy), neither do we, and the predicate still names the object that
+ * actually crashes.
  */
-const canServeModernRoute = (server: unknown): boolean =>
-  Array.isArray(
-    (server as { _supportedProtocolVersions?: unknown })
+const canServeModernRoute = (server: unknown): boolean => {
+  const target = server instanceof McpServer ? server.server : server;
+
+  return Array.isArray(
+    (target as { _supportedProtocolVersions?: unknown })
       ._supportedProtocolVersions,
   );
+};
 
 /**
  * `createMcpHandler`'s factory is handed an era, not the underlying Node

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -833,6 +833,30 @@ type ModernLeg<T> = {
 };
 
 /**
+ * Whether a freshly built server instance can serve the 2026-07-28 modern
+ * route.
+ *
+ * The first thing the modern SDK handler does when it starts serving a modern
+ * request is dereference `server._supportedProtocolVersions` (an array) inside
+ * `installDiscoverHandler`. A server built by the 1.x MCP SDK - which is what
+ * fastmcp <=4.x hands mcp-proxy through its `^6.4.6` range - never sets that
+ * property, so the dereference throws `Cannot read properties of undefined
+ * (reading 'includes')` before the session is usable, and the failure surfaces
+ * only against real 2026-07-28 traffic while legacy-handshake tests stay green
+ * (issue #96).
+ *
+ * Duck-typing the exact property the SDK reads is the narrowest predicate that
+ * predicts the crash: it does not depend on SDK class identity (unreliable
+ * across duplicated or hoisted copies of the SDK) and it keeps working if some
+ * future non-SDK server legitimately declares the same array.
+ */
+const canServeModernRoute = (server: unknown): boolean =>
+  Array.isArray(
+    (server as { _supportedProtocolVersions?: unknown })
+      ._supportedProtocolVersions,
+  );
+
+/**
  * `createMcpHandler`'s factory is handed an era, not the underlying Node
  * request, but `createServer` is defined in terms of that request (consumers
  * derive per-request auth and context from it). `AsyncLocalStorage` carries the
@@ -901,6 +925,34 @@ const createModernLeg = <T extends ServerLike>({
     target.onclose = teardown;
 
     try {
+      // Refuse the modern route cleanly when `createServer` handed us an
+      // instance the 2026-07-28 SDK handler cannot serve (a 1.x-SDK server -
+      // see `canServeModernRoute`). Throwing here rather than routing to
+      // `handle` turns what would be an opaque 500 from a TypeError deep inside
+      // the SDK into a proper "unsupported protocol version" JSON-RPC error:
+      // the throw runs the same teardown as any other `createInstance` failure
+      // and reaches `handleCreateServerError`, which honors a thrown `Response`
+      // verbatim. The check lives inside the try so the just-built instance is
+      // torn down (its upstream sink released) exactly as on any other failure.
+      if (!canServeModernRoute(server)) {
+        throw new Response(
+          JSON.stringify({
+            error: {
+              code: -32000,
+              data: { reason: "server_missing_modern_protocol_support" },
+              message:
+                "Unsupported protocol version: the server instance cannot serve the 2026-07-28 protocol revision. It was built by the 1.x MCP SDK (e.g. fastmcp <=4.x pulling mcp-proxy through its `^6.4.6` range), which does not declare `_supportedProtocolVersions`. Upgrade the framework that builds it, or serve only 2025-era clients (`modern: false`).",
+            },
+            id: getRequestId(body),
+            jsonrpc: "2.0",
+          }),
+          {
+            headers: { "content-type": "application/json" },
+            status: 400,
+          },
+        );
+      }
+
       if (onListenSubscriptions) {
         const listenUris = readListenSubscriptions(body);
 


### PR DESCRIPTION
Fixes #96.

### The crash

When `mcp-proxy` fronts a server built by the **1.x** MCP SDK (what `fastmcp` ≤4.x pulls in through its `mcp-proxy` `^6.4.6` range) and a **modern** client (2026-07-28 era, e.g. Claude) connects, the modern leg crashes with a 500:

```
TypeError: Cannot read properties of undefined (reading 'includes')
    at installDiscoverHandler (@modelcontextprotocol/server/src/server/server.ts:275)
```

`createModernLeg.createInstance` routes the request straight to the SDK's modern handler, whose first act is `server._supportedProtocolVersions.includes(...)`. A 1.x-SDK server never sets that property → `TypeError` → `{"code":-32603,"message":"Internal server error"}`. Legacy handshakes stay green, so it only surfaces against real modern traffic — which is why @jordanburke saw it as recurring 500s / degraded sessions rather than a startup failure.

### The fix (option **a** from @es617's proposal — clean refusal)

Before routing to the SDK handler, detect the incompatible instance and throw a `Response` carrying an "unsupported protocol version" JSON-RPC error. It flows through the existing thrown-`Response` → `handleCreateServerError` → `handleResponseError` path, and sits as the first statement in `createInstance`'s `try` so the just-built instance is torn down exactly as on any other failure. Result: a clean **400** JSON-RPC error instead of a 500 crash.

Detection duck-types the exact property the SDK dereferences, rather than `instanceof Server`:

```ts
const canServeModernRoute = (server: unknown): boolean =>
  Array.isArray((server as { _supportedProtocolVersions?: unknown })._supportedProtocolVersions);
```

The whole failure mode is two SDK majors coexisting in one dependency tree, where class identity is unreliable across duplicated/hoisted copies — but the property the SDK actually reads is not.

### Why (a) over (b)

Falling through to the 2025-era session machinery (option **b**) would be friendlier *if* that machinery can serve traffic already classified non-legacy — but `isLegacyRequest` deliberately said it isn't, so handing it to the legacy leg is an unverified assumption that risks a different mis-handling. (a) is deterministic and cannot crash; the door to (b) is left open in the error payload (`modern: false`) for maintainer preference. A modern client fronting a 1.x-SDK server genuinely cannot speak the modern protocol, so a clear error is the honest outcome — strictly better than the current hard-crash.

### Test

New regression `src/startHTTPServer.modern-era-guard.test.ts`: builds a real 2.x `Server` with `_supportedProtocolVersions` deleted (the narrowest faithful stand-in for a 1.x server) and POSTs a modern-classified `tools/list`.
- **Before:** SDK `TypeError` logged, status 500.
- **After:** no crash, status 400, JSON-RPC error matching `/unsupported protocol version/i`, echoes the request id.

Neighbors green (`startHTTPServer` / `get-stream-error` / `headers-sent` / `protocolEras` / `proxyServer` / `upstreamNotifications` — 120 passed across 7 files); `tsc` and `eslint` clean on the changed files.
