### PR TITLE
fix(bin): guard graceful shutdown against a double server.close()

### DIFF
--- a/src/bin/mcp-proxy.ts
+++ b/src/bin/mcp-proxy.ts
@@ -13,10 +13,10 @@ import { hideBin } from "yargs/helpers";
 const require = createRequire(import.meta.url);
 const packageJson = require("../../package.json") as { version: string };
 
+import { createGracefulShutdown } from "../createGracefulShutdown.js";
 import { proxyServer } from "../proxyServer.js";
 import {
   DEFAULT_ALLOWED_HEADERS,
-  SSEServer,
   startHTTPServer,
 } from "../startHTTPServer.js";
 import {
@@ -379,32 +379,6 @@ const proxy = async () => {
         await tunnel.close();
       }
     },
-  };
-};
-
-const createGracefulShutdown = ({
-  server,
-  timeout,
-}: {
-  server: Pick<SSEServer, "close">;
-  timeout: number;
-}) => {
-  const gracefulShutdown = () => {
-    console.info("received shutdown signal; shutting down");
-
-    server.close();
-
-    setTimeout(() => {
-      // Exit with non-zero code to indicate failure to shutdown gracefully
-      process.exit(1);
-    }, timeout).unref();
-  };
-
-  process.once("SIGTERM", gracefulShutdown);
-  process.once("SIGINT", gracefulShutdown);
-
-  return () => {
-    server.close();
   };
 };
 

--- a/src/createGracefulShutdown.test.ts
+++ b/src/createGracefulShutdown.test.ts
@@ -1,0 +1,107 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { createGracefulShutdown } from "./createGracefulShutdown.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it("runs the teardown once and never drops a rejected close when two signals arrive", async () => {
+  // Regression test: SIGTERM and SIGINT both invoke the shutdown handler and
+  // there was no re-entrancy guard, so a second signal (Ctrl-C then SIGTERM)
+  // called `server.close()` again. The SDK rejects the redundant close, and
+  // because the promise was dropped it surfaced as an unhandledRejection that
+  // crashed the shutdown with a non-zero exit.
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "info").mockImplementation(() => {});
+
+  // Capture the registered handlers instead of emitting real process signals,
+  // which would tear down the test runner.
+  const handlers = new Map<string, () => void>();
+  vi.spyOn(process, "once").mockImplementation(
+    (event: string | symbol, handler: (...args: unknown[]) => void) => {
+      handlers.set(String(event), handler as () => void);
+      return process;
+    },
+  );
+
+  let closeCalls = 0;
+  const close = vi.fn(async () => {
+    closeCalls += 1;
+
+    if (closeCalls > 1) {
+      // Mirrors the SDK closing an already-closing server.
+      throw new Error("Server is not running.");
+    }
+  });
+
+  try {
+    createGracefulShutdown({ server: { close }, timeout: 5_000 });
+
+    const sigint = handlers.get("SIGINT");
+    const sigterm = handlers.get("SIGTERM");
+    expect(sigint).toBeDefined();
+    expect(sigterm).toBeDefined();
+
+    // Two signals arriving close together, e.g. Ctrl-C followed by SIGTERM.
+    sigint?.();
+    sigterm?.();
+
+    // Give any dropped rejection a chance to surface.
+    await delay(100);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(unhandledRejections).toEqual([]);
+  } finally {
+    consoleError.mockRestore();
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+});
+
+it("reports a failing close via console.error instead of leaving it unhandled", async () => {
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "info").mockImplementation(() => {});
+
+  const handlers = new Map<string, () => void>();
+  vi.spyOn(process, "once").mockImplementation(
+    (event: string | symbol, handler: (...args: unknown[]) => void) => {
+      handlers.set(String(event), handler as () => void);
+      return process;
+    },
+  );
+
+  const closeError = new Error("close failed");
+  const close = vi.fn(async () => {
+    throw closeError;
+  });
+
+  try {
+    createGracefulShutdown({ server: { close }, timeout: 5_000 });
+
+    handlers.get("SIGTERM")?.();
+
+    await delay(100);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[mcp-proxy] error during shutdown",
+      closeError,
+    );
+    expect(unhandledRejections).toEqual([]);
+  } finally {
+    consoleError.mockRestore();
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+});

--- a/src/createGracefulShutdown.ts
+++ b/src/createGracefulShutdown.ts
@@ -1,0 +1,56 @@
+import { setTimeout } from "node:timers";
+
+import { type SSEServer } from "./startHTTPServer.js";
+
+export const createGracefulShutdown = ({
+  server,
+  timeout,
+}: {
+  server: Pick<SSEServer, "close">;
+  timeout: number;
+}) => {
+  // Both SIGTERM and SIGINT run `gracefulShutdown`, and the returned callback
+  // is a third caller. `server.close()` is a promise that rejects when the
+  // server is already closing, so a second invocation - Ctrl-C followed by
+  // SIGTERM, or a signal after the manual callback - would drop a rejected
+  // promise and crash the process on `unhandledRejection`. This flag makes the
+  // teardown run exactly once, and `closeServer` never leaves its promise
+  // unhandled.
+  let shuttingDown = false;
+
+  const closeServer = () => {
+    void server.close().catch((error: unknown) => {
+      console.error("[mcp-proxy] error during shutdown", error);
+    });
+  };
+
+  const gracefulShutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+
+    console.info("received shutdown signal; shutting down");
+
+    closeServer();
+
+    setTimeout(() => {
+      // Exit with non-zero code to indicate failure to shutdown gracefully
+      process.exit(1);
+    }, timeout).unref();
+  };
+
+  process.once("SIGTERM", gracefulShutdown);
+  process.once("SIGINT", gracefulShutdown);
+
+  return () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+
+    closeServer();
+  };
+};


### PR DESCRIPTION
### The bug

`createGracefulShutdown` in `src/bin/mcp-proxy.ts` registers the **same** handler for both `SIGTERM` and `SIGINT`, with no re-entrancy guard, and calls `server.close()` (a Promise) with **no `await` and no `.catch()`** in three places (the signal handler and the returned manual-shutdown callback).

A second invocation — Ctrl-C followed by SIGTERM, both signals arriving together, or a signal after the manual callback already ran — calls `server.close()` on an already-closing server. That second call rejects; the dropped promise surfaces as an `unhandledRejection`, turning a clean shutdown into a noisy, non-zero exit. Same family as the already-merged #81 / #95.

### The fix (minimal)

- A shared `shuttingDown` flag so teardown runs **once**.
- Every `close()` routed through a `closeServer()` helper: `void server.close().catch(err => console.error("[mcp-proxy] error during shutdown", err))` — so a late/duplicate close is logged, never unhandled.

`createGracefulShutdown` is extracted into its own module `src/createGracefulShutdown.ts` so it can be unit-tested: the bin file runs `await main()` and parses argv at import time, so it isn't importable as-is. This mirrors the repo's one-module-per-concern layout; the bin now imports the helper.

### Test

New `src/createGracefulShutdown.test.ts` (2 tests), capturing the `process.once` signal handlers via a spy and asserting `process.on('unhandledRejection')` stays empty — the repo's existing idiom.
- **Before:** RED — `close` called 2 times (double close), and the rejection path leaves an unhandled rejection.
- **After:** GREEN — teardown runs once, the duplicate close is caught and logged.

Reachability note: the second `close()` rejection is the SDK's already-closing rejection; I model it with a representative `"Server is not running."` error rather than driving a real SDK server through a double close — but the **double-close itself is real and directly observed** (2 calls in the RED run).

Full CI green locally (`vitest run && tsc && eslint . && jsr publish --dry-run`): **194 tests passed**, tsc + eslint clean, jsr dry-run success.
