### PR TITLE
fix(auth): always send WWW-Authenticate on 401 per RFC 7235

### DIFF
--- a/src/authentication.test.ts
+++ b/src/authentication.test.ts
@@ -133,11 +133,14 @@ describe("AuthenticationMiddleware", () => {
       expect(response1.body).toEqual(response2.body);
     });
 
-    it("should not include WWW-Authenticate header without OAuth config", () => {
+    it("should include WWW-Authenticate header without OAuth config", () => {
       const middleware = new AuthenticationMiddleware({ apiKey: "test" });
       const response = middleware.getUnauthorizedResponse();
 
-      expect(response.headers["WWW-Authenticate"]).toBeUndefined();
+      // RFC 7235 requires a challenge on every 401, OAuth config or not.
+      expect(response.headers["WWW-Authenticate"]).toBe(
+        'Bearer error="invalid_token", error_description="Unauthorized: Invalid or missing API key"',
+      );
     });
 
     it("should include WWW-Authenticate header with OAuth config", () => {

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -74,52 +74,48 @@ export class AuthenticationMiddleware {
       "Content-Type": "application/json",
     };
 
-    // Build WWW-Authenticate header if OAuth config is available
-    if (this.config.oauth) {
-      const params: string[] = [];
+    // RFC 7235 requires every 401 to carry a challenge, so this is always built.
+    // OAuth config only enriches it with the optional auth-params.
+    const params: string[] = [];
 
-      // Add realm if configured
-      if (this.config.oauth.realm) {
-        params.push(`realm="${this.config.oauth.realm}"`);
-      }
-
-      // Add resource_metadata if configured
-      if (this.config.oauth.protectedResource?.resource) {
-        params.push(
-          `resource_metadata="${this.config.oauth.protectedResource.resource}/.well-known/oauth-protected-resource"`,
-        );
-      }
-
-      // Add error from options or config (options takes precedence)
-      const error =
-        options?.error || this.config.oauth.error || "invalid_token";
-      params.push(`error="${error}"`);
-
-      // Add error_description from options or config (options takes precedence)
-      const error_description =
-        options?.error_description ||
-        this.config.oauth.error_description ||
-        "Unauthorized: Invalid or missing API key";
-      // Escape quotes in error description
-      const escaped = error_description.replace(/"/g, '\\"');
-      params.push(`error_description="${escaped}"`);
-
-      // Add error_uri from options or config (options takes precedence)
-      const error_uri = options?.error_uri || this.config.oauth.error_uri;
-      if (error_uri) {
-        params.push(`error_uri="${error_uri}"`);
-      }
-
-      // Add scope from options or config (options takes precedence)
-      const scope = options?.scope || this.config.oauth.scope;
-      if (scope) {
-        params.push(`scope="${scope}"`);
-      }
-
-      if (params.length > 0) {
-        headers["WWW-Authenticate"] = `Bearer ${params.join(", ")}`;
-      }
+    // Add realm if configured
+    if (this.config.oauth?.realm) {
+      params.push(`realm="${this.config.oauth.realm}"`);
     }
+
+    // Add resource_metadata if configured
+    if (this.config.oauth?.protectedResource?.resource) {
+      params.push(
+        `resource_metadata="${this.config.oauth.protectedResource.resource}/.well-known/oauth-protected-resource"`,
+      );
+    }
+
+    // Add error from options or config (options takes precedence)
+    const error = options?.error || this.config.oauth?.error || "invalid_token";
+    params.push(`error="${error}"`);
+
+    // Add error_description from options or config (options takes precedence)
+    const error_description =
+      options?.error_description ||
+      this.config.oauth?.error_description ||
+      "Unauthorized: Invalid or missing API key";
+    // Escape quotes in error description
+    const escaped = error_description.replace(/"/g, '\\"');
+    params.push(`error_description="${escaped}"`);
+
+    // Add error_uri from options or config (options takes precedence)
+    const error_uri = options?.error_uri || this.config.oauth?.error_uri;
+    if (error_uri) {
+      params.push(`error_uri="${error_uri}"`);
+    }
+
+    // Add scope from options or config (options takes precedence)
+    const scope = options?.scope || this.config.oauth?.scope;
+    if (scope) {
+      params.push(`scope="${scope}"`);
+    }
+
+    headers["WWW-Authenticate"] = `Bearer ${params.join(", ")}`;
 
     return {
       body: JSON.stringify({

--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -2124,7 +2124,7 @@ it("includes WWW-Authenticate header when authenticate callback fails with OAuth
   await httpServer.close();
 });
 
-it("does not include WWW-Authenticate header in 401 response without OAuth config", async () => {
+it("includes WWW-Authenticate header in 401 response without OAuth config", async () => {
   const port = await getRandomPort();
 
   const httpServer = await startHTTPServer({
@@ -2155,8 +2155,58 @@ it("does not include WWW-Authenticate header in 401 response without OAuth confi
 
   expect(response.status).toBe(401);
 
+  // RFC 7235 requires a challenge on every 401, OAuth config or not.
   const wwwAuthHeader = response.headers.get("WWW-Authenticate");
-  expect(wwwAuthHeader).toBeNull();
+  expect(wwwAuthHeader).toBe(
+    'Bearer error="invalid_token", error_description="Authentication required"',
+  );
+
+  await httpServer.close();
+});
+
+it("includes WWW-Authenticate header when authenticate rejects without OAuth config", async () => {
+  const port = await getRandomPort();
+
+  const httpServer = await startHTTPServer({
+    authenticate: async () => ({
+      authenticated: false,
+      error: "Access denied",
+    }),
+    createServer: async () =>
+      new Server({ name: "test", version: "1.0.0" }, { capabilities: {} }),
+    port,
+    stateless: true,
+  });
+
+  const response = await fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      id: 7,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0.0" },
+        protocolVersion: "2024-11-05",
+      },
+    }),
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  expect(response.status).toBe(401);
+  expect(response.headers.get("WWW-Authenticate")).toBe(
+    'Bearer error="invalid_token", error_description="Access denied"',
+  );
+
+  // The JSON-RPC id of the rejected request is echoed back.
+  expect(await response.json()).toEqual({
+    error: { code: -32000, message: "Access denied" },
+    id: 7,
+    jsonrpc: "2.0",
+  });
 
   await httpServer.close();
 });

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -405,7 +405,11 @@ const readListenSubscriptions = (body: unknown): string[] => {
     : [];
 };
 
-// Helper function to get WWW-Authenticate header value
+// Helper function to get WWW-Authenticate header value.
+//
+// RFC 7235 requires every 401 to carry at least one challenge, so this always
+// returns a `Bearer` challenge; OAuth config only enriches it with the optional
+// auth-params. Do not use this for a 403, which has no such requirement.
 const getWWWAuthenticateHeader = (
   oauth?: AuthConfig["oauth"],
   options?: {
@@ -414,34 +418,30 @@ const getWWWAuthenticateHeader = (
     error_uri?: string;
     scope?: string;
   },
-): string | undefined => {
-  if (!oauth) {
-    return undefined;
-  }
-
+): string => {
   const params: string[] = [];
 
   // Add realm if configured
-  if (oauth.realm) {
+  if (oauth?.realm) {
     params.push(`realm="${oauth.realm}"`);
   }
 
   // Add resource_metadata if configured
-  if (oauth.protectedResource?.resource) {
+  if (oauth?.protectedResource?.resource) {
     params.push(
       `resource_metadata="${oauth.protectedResource.resource}/.well-known/oauth-protected-resource"`,
     );
   }
 
   // Add error from options or config (options takes precedence)
-  const error = options?.error || oauth.error;
+  const error = options?.error || oauth?.error;
   if (error) {
     params.push(`error="${error}"`);
   }
 
   // Add error_description from options or config (options takes precedence)
   const error_description =
-    options?.error_description || oauth.error_description;
+    options?.error_description || oauth?.error_description;
   if (error_description) {
     // Escape quotes in error description
     const escaped = error_description.replace(/"/g, '\\"');
@@ -449,20 +449,20 @@ const getWWWAuthenticateHeader = (
   }
 
   // Add error_uri from options or config (options takes precedence)
-  const error_uri = options?.error_uri || oauth.error_uri;
+  const error_uri = options?.error_uri || oauth?.error_uri;
   if (error_uri) {
     params.push(`error_uri="${error_uri}"`);
   }
 
   // Add scope from options or config (options takes precedence)
-  const scope = options?.scope || oauth.scope;
+  const scope = options?.scope || oauth?.scope;
   if (scope) {
     params.push(`scope="${scope}"`);
   }
 
-  // Return undefined if no parameters were added
+  // A bare `Bearer` is a valid challenge (RFC 7235); auth-params are optional.
   if (params.length === 0) {
-    return undefined;
+    return "Bearer";
   }
 
   return `Bearer ${params.join(", ")}`;
@@ -481,9 +481,7 @@ const sendSessionUnauthorizedResponse = ({
     error: "invalid_token",
     error_description: message,
   });
-  if (wwwAuthHeader) {
-    res.setHeader("WWW-Authenticate", wwwAuthHeader);
-  }
+  res.setHeader("WWW-Authenticate", wwwAuthHeader);
 
   res.writeHead(401).end(
     JSON.stringify({
@@ -614,9 +612,7 @@ const handleCreateServerError = async ({
       error_description: errorMessage,
     });
 
-    if (wwwAuthHeader) {
-      res.setHeader("WWW-Authenticate", wwwAuthHeader);
-    }
+    res.setHeader("WWW-Authenticate", wwwAuthHeader);
 
     res.writeHead(401).end(
       JSON.stringify({
@@ -1257,14 +1253,12 @@ const handleStreamRequest = async <T extends ServerLike>({
 
             res.setHeader("Content-Type", "application/json");
 
-            // Add WWW-Authenticate header if OAuth config is available
+            // RFC 7235: a 401 always carries a challenge, OAuth config or not
             const wwwAuthHeader = getWWWAuthenticateHeader(oauth, {
               error: "invalid_token",
               error_description: errorMessage,
             });
-            if (wwwAuthHeader) {
-              res.setHeader("WWW-Authenticate", wwwAuthHeader);
-            }
+            res.setHeader("WWW-Authenticate", wwwAuthHeader);
 
             res.writeHead(401).end(
               JSON.stringify({
@@ -1292,14 +1286,12 @@ const handleStreamRequest = async <T extends ServerLike>({
           console.error("Authentication error:", error);
           res.setHeader("Content-Type", "application/json");
 
-          // Add WWW-Authenticate header if OAuth config is available
+          // RFC 7235: a 401 always carries a challenge, OAuth config or not
           const wwwAuthHeader = getWWWAuthenticateHeader(oauth, {
             error: "invalid_token",
             error_description: errorMessage,
           });
-          if (wwwAuthHeader) {
-            res.setHeader("WWW-Authenticate", wwwAuthHeader);
-          }
+          res.setHeader("WWW-Authenticate", wwwAuthHeader);
 
           res.writeHead(401).end(
             JSON.stringify({


### PR DESCRIPTION
RFC 7235 §3.1: a 401 MUST carry at least one challenge. We only sent one when `oauth` was configured.

- `getWWWAuthenticateHeader` no longer bails on missing `oauth`; it always returns a `Bearer` challenge (bare `Bearer` if there are no auth-params). OAuth config just adds `realm`/`resource_metadata`. Return type is now `string`, so the four dead truthiness guards at the call sites are gone.
- Same guard removed from `AuthenticationMiddleware.getUnauthorizedResponse` (the API-key 401).
- 403 `insufficient_scope` is untouched — no such requirement there.

In practice every 401 path already passes `error`/`error_description`, so callers with no OAuth config now get `Bearer error="invalid_token", error_description="<reason>"`.

Downstream: fastmcp had to pass `oauth: {}` purely to unblock this header (punkpeye/fastmcp#358, punkpeye/fastmcp#357). That shim becomes unnecessary once this ships.

Two tests that pinned the old behavior are inverted; adds coverage for `authenticate()` rejecting with no OAuth config (header present, JSON-RPC `id` still echoed).