### PR TITLE
fix(http): clean up failed legacy SSE sessions

### DIFF
--- a/src/startHTTPServer.test.ts
+++ b/src/startHTTPServer.test.ts
@@ -2929,16 +2929,18 @@ it("does not crash when the SSE connect error path runs after headers are sent",
   };
   process.on("unhandledRejection", onUnhandledRejection);
   const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  const server = new Server(
+    { name: "test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  const close = vi.spyOn(server, "close");
+  const onClose = vi.fn();
 
   const httpServer = await startHTTPServer({
-    createServer: async () => {
-      return new Server(
-        { name: "test", version: "1.0.0" },
-        { capabilities: {} },
-      );
-    },
+    createServer: async () => server,
     // server.connect() and the initial transport.send() succeed, so the
     // SSE 200 headers are already on the wire when this throws.
+    onClose,
     onConnect: async () => {
       throw new Error("simulated connect failure");
     },
@@ -2959,8 +2961,11 @@ it("does not crash when the SSE connect error path runs after headers are sent",
     await delay(100);
 
     expect(unhandledRejections).toEqual([]);
+    expect(close).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
   } finally {
     await httpServer.close();
+    close.mockRestore();
     consoleError.mockRestore();
     process.off("unhandledRejection", onUnhandledRejection);
   }

--- a/src/startHTTPServer.ts
+++ b/src/startHTTPServer.ts
@@ -1758,8 +1758,20 @@ const handleSSERequest = async <T extends ServerLike>({
       if (!closed) {
         console.error("[mcp-proxy] error connecting to server", error);
 
+        // This session was published in activeTransports before connect so
+        // legacy clients could use the endpoint sent over SSE. A failure here
+        // leaves that entry unusable and keeps any server-owned resources
+        // alive unless we tear it down explicitly. Claim cleanup before
+        // closing: server.close() closes the transport, which re-enters the
+        // response close handler above.
+        isCleaningUp = true;
+        await cleanupServer(server, onClose);
+        delete activeTransports[transport.sessionId];
+
         if (!res.headersSent) {
           res.writeHead(500).end("Error connecting to server");
+        } else {
+          res.end();
         }
       }
     }


### PR DESCRIPTION
## Summary

- clean up the MCP server when legacy SSE setup fails after the session was published
- remove the unusable transport from `activeTransports`
- end a response whose SSE headers are already committed
- assert server close and `onClose` each run exactly once

The transport is made visible before `server.connect()` and the initial send finish. If `onConnect` then rejects, the previous path logged the error but retained both the active session and server-owned resources. Cleanup is claimed before closing because `server.close()` can re-enter the response close handler.

## Validation

- regression test observes zero closes on the parent commit and exactly one close after the fix
- `pnpm test` (197 tests, TypeScript, ESLint, JSR publish dry-run)
