### PR TITLE
fix(stdio): close upstream after startup failure

### DIFF
--- a/src/startStdioServer.ts
+++ b/src/startStdioServer.ts
@@ -94,39 +94,48 @@ export const startStdioServer = async ({
 
   await streamClient.connect(transport);
 
-  const serverVersion = streamClient.getServerVersion() as {
-    name: string;
-    version: string;
-  };
+  try {
+    const serverVersion = streamClient.getServerVersion() as {
+      name: string;
+      version: string;
+    };
 
-  const serverCapabilities =
-    streamClient.getServerCapabilities() as ServerCapabilities;
+    const serverCapabilities =
+      streamClient.getServerCapabilities() as ServerCapabilities;
 
-  const stdioServer = initStdioServer
-    ? await initStdioServer()
-    : new Server(serverVersion, {
-        capabilities: serverCapabilities,
-      });
+    const stdioServer = initStdioServer
+      ? await initStdioServer()
+      : new Server(serverVersion, {
+          capabilities: serverCapabilities,
+        });
 
-  await proxyServer({
-    client: streamClient,
-    server: stdioServer,
-    serverCapabilities,
-  });
+    await proxyServer({
+      client: streamClient,
+      server: stdioServer,
+      serverCapabilities,
+    });
 
-  // A bare `connect(new StdioServerTransport())`, which binds the connection to
-  // the 2025 era at `initialize`. Serving 2026-07-28 here needs `serveStdio`,
-  // and that entry wants a factory it can call more than once - it builds a
-  // separate instance for a `server/discover` probe and closes it again. Handing
-  // it this one instance instead lets the probe pin its version and then close
-  // it, which leaves the connection answering neither era; and because the entry
-  // connects a transport only when the first message arrives, the `Server` this
-  // function returns would no longer be connected when it returns.
-  //
-  // Both are fixable, but not by reusing one instance, so this stays on the
-  // 2025-era path until the return contract is reworked to hand back the
-  // entry's own handle.
-  await stdioServer.connect(new StdioServerTransport());
+    // A bare `connect(new StdioServerTransport())`, which binds the connection to
+    // the 2025 era at `initialize`. Serving 2026-07-28 here needs `serveStdio`,
+    // and that entry wants a factory it can call more than once - it builds a
+    // separate instance for a `server/discover` probe and closes it again. Handing
+    // it this one instance instead lets the probe pin its version and then close
+    // it, which leaves the connection answering neither era; and because the entry
+    // connects a transport only when the first message arrives, the `Server` this
+    // function returns would no longer be connected when it returns.
+    //
+    // Both are fixable, but not by reusing one instance, so this stays on the
+    // 2025-era path until the return contract is reworked to hand back the
+    // entry's own handle.
+    await stdioServer.connect(new StdioServerTransport());
 
-  return stdioServer;
+    return stdioServer;
+  } catch (error) {
+    try {
+      await streamClient.close();
+    } catch {
+      // Preserve the startup error; cleanup failure is secondary here.
+    }
+    throw error;
+  }
 };

--- a/src/startStdioServer.unit.test.ts
+++ b/src/startStdioServer.unit.test.ts
@@ -1,0 +1,73 @@
+import type { Client } from "@modelcontextprotocol/client";
+import type { Server } from "@modelcontextprotocol/server";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { proxyServer } from "./proxyServer.js";
+import { ServerType, startStdioServer } from "./startStdioServer.js";
+
+vi.mock("./proxyServer.js", () => ({ proxyServer: vi.fn() }));
+
+const clientWithClose = (close: () => Promise<void>) =>
+  ({
+    close,
+    connect: vi.fn().mockResolvedValue(undefined),
+    getServerCapabilities: vi.fn().mockReturnValue({}),
+    getServerVersion: vi
+      .fn()
+      .mockReturnValue({ name: "upstream", version: "1" }),
+  }) as unknown as Client;
+
+describe("startStdioServer startup cleanup", () => {
+  it("closes an already-connected upstream client when stdio setup fails", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const client = clientWithClose(close);
+    const startupError = new Error("stdio setup failed");
+
+    await expect(
+      startStdioServer({
+        initStdioServer: vi.fn().mockRejectedValue(startupError),
+        initStreamClient: vi.fn().mockResolvedValue(client),
+        serverType: ServerType.HTTPStream,
+        url: "https://example.com/mcp",
+      }),
+    ).rejects.toBe(startupError);
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the startup error when closing the upstream client also fails", async () => {
+    const close = vi.fn().mockRejectedValue(new Error("close failed"));
+    const client = clientWithClose(close);
+    const startupError = new Error("stdio setup failed");
+
+    await expect(
+      startStdioServer({
+        initStdioServer: vi.fn().mockRejectedValue(startupError),
+        initStreamClient: vi.fn().mockResolvedValue(client),
+        serverType: ServerType.HTTPStream,
+        url: "https://example.com/mcp",
+      }),
+    ).rejects.toBe(startupError);
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("closes the upstream client when proxy initialization fails", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const client = clientWithClose(close);
+    const startupError = new Error("proxy setup failed");
+    vi.mocked(proxyServer).mockRejectedValueOnce(startupError);
+
+    await expect(
+      startStdioServer({
+        initStdioServer: vi.fn().mockResolvedValue({} as Server),
+        initStreamClient: vi.fn().mockResolvedValue(client),
+        serverType: ServerType.HTTPStream,
+        url: "https://example.com/mcp",
+      }),
+    ).rejects.toBe(startupError);
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- close an already-connected upstream client when a later stdio startup phase fails
- preserve the original startup error if cleanup also fails
- cover stdio initialization and proxy initialization failures

`startStdioServer` connects the upstream client before creating and connecting the local stdio server. If any later step rejects, the previous path leaves that upstream connection open. This change scopes the post-connect setup in a cleanup boundary and closes the client before rethrowing the original failure.

## Validation

- 3 focused startup-cleanup tests pass
- type checking, ESLint, Prettier and build pass